### PR TITLE
Refiner

### DIFF
--- a/@sdpvar/addfactors.m
+++ b/@sdpvar/addfactors.m
@@ -1,5 +1,5 @@
 function Z = addfactors(Z,X,Y)
-if isa(X,'double') || isa(X,'logical')
+if isnumeric(X) || isa(X,'logical')
     if length(Y.midfactors)==0
         return
     end
@@ -15,7 +15,7 @@ if isa(X,'double') || isa(X,'logical')
         Z.leftfactors{end+1} = 1;
         Z.rightfactors{end+1} = 1;
     end
-elseif isa(Y,'double') || isa(Y,'logical')
+elseif isnumeric(Y) || isa(Y,'logical')
     if length(X.midfactors)==0
         return
     end

--- a/@sdpvar/addgkyp.m
+++ b/@sdpvar/addgkyp.m
@@ -9,11 +9,11 @@ if ~((prod(sx)==1) | (prod(sy)==1))
     end
 end
 
-if isa(Y,'double') | (isa(Y,'sdpvar') & ~is(Y,'gkyp'))   
+if isnumeric(Y) | (isa(Y,'sdpvar') & ~is(Y,'gkyp'))   
     X.extra.M =  X.extra.M+Y;
     X.typeflag = 0;
     y = X+Y;
-    if isa(y,'double')
+    if isnumeric(y)
         return
     else
         y.typeflag = 40;
@@ -31,7 +31,7 @@ else
     y.typeflag = 0;
     Y.typeflag = 0;
     y = y+Y;
-    if isa(y,'double')
+    if isnumeric(y)
         return
     else
         y.typeflag = 40;

--- a/@sdpvar/assign.m
+++ b/@sdpvar/assign.m
@@ -25,8 +25,8 @@ if isa(value,'logical')
     value = double(value);
 end
 
-if ~isa(value,'double')
-    error('Second argument should be a DOUBLE.');
+if ~isnumeric(value)
+    error('Second argument should be NUMERIC.');
 end
 
 if prod(size(value)) == 1

--- a/@sdpvar/blkdiag.m
+++ b/@sdpvar/blkdiag.m
@@ -80,7 +80,7 @@ for i = 1:length(varargin)
             y.leftfactors{end+1} = [zeros(sum(n(1:1:i-1)),size(varargin{i}.leftfactors{j},2)); varargin{i}.leftfactors{j}; zeros(sum(n(i+1:1:end)),size(varargin{i}.leftfactors{j},2))];
             y.midfactors{end+1} = varargin{i}.midfactors{j};
         end
-    elseif isa(varargin{i},'double')       
+    elseif isumeric(varargin{i})
         here = length(y.midfactors)+1;
         y.rightfactors{here} = [zeros(m(i),sum(m(1:1:i-1))) eye(m(i)) zeros(m(i),sum(m(i+1:1:end)))];
         y.leftfactors{here} = [zeros(sum(n(1:1:i-1)),size(varargin{i},1)); eye(size(varargin{i},1)); zeros(sum(n(i+1:1:end)),size(varargin{i},1))];

--- a/@sdpvar/cleandoublefactors.m
+++ b/@sdpvar/cleandoublefactors.m
@@ -5,19 +5,19 @@ if isempty(Z.midfactors)
 end
 
 for i = 1:length(Z.midfactors)
-    isdouble(i) = isa(Z.midfactors{i},'double');
+    isnumeriq(i) = isnumeric(Z.midfactors{i});
 end
-isdouble = find(isdouble);
-if length(isdouble)>1
-    total = Z.leftfactors{isdouble(1)}*Z.midfactors{isdouble(1)}*Z.rightfactors{isdouble(1)};
-    for i = isdouble(2:end)
+isnumeriq = find(isnumeriq);
+if length(isnumeriq)>1
+    total = Z.leftfactors{isnumeriq(1)}*Z.midfactors{isnumeriq(1)}*Z.rightfactors{isnumeriq(1)};
+    for i = isnumeriq(2:end)
         total = total + Z.leftfactors{i}*Z.midfactors{i}*Z.rightfactors{i};
     end
     allfactors = 1:length(Z.midfactors);
-    keepfactors = setdiff(allfactors,isdouble(2:end));
-    Z.midfactors{isdouble(1)} = total;
-    Z.leftfactors{isdouble(1)} = speye(size(total,1));
-    Z.rightfactors{isdouble(1)} = speye(size(total,2));
+    keepfactors = setdiff(allfactors,isnumeriq(2:end));
+    Z.midfactors{isnumeriq(1)} = total;
+    Z.leftfactors{isnumeriq(1)} = speye(size(total,1));
+    Z.rightfactors{isnumeriq(1)} = speye(size(total,2));
     Z.leftfactors = {Z.leftfactors{keepfactors}};
     Z.rightfactors = {Z.rightfactors{keepfactors}};
     Z.midfactors = {Z.midfactors{keepfactors}};

--- a/@sdpvar/conv.m
+++ b/@sdpvar/conv.m
@@ -1,7 +1,7 @@
 function Z=conv(X,Y)
 %CONV (overloaded)
 
-if isa(X,'double')
+if isnumeric(X)
     temp = X;
     X = Y;
     Y = temp;

--- a/@sdpvar/degree.m
+++ b/@sdpvar/degree.m
@@ -31,7 +31,7 @@ if nargin == 3
    
 end
 
-if isa(p,'double')
+if isnumeric(p)
     if nargin==1
         deg = 0;
     else
@@ -82,7 +82,7 @@ else
         z.type = '()';
         z.subs{1} = i;
         pi = subsref(p,z);
-        if isa(pi,'double')
+        if isnumeric(pi)
             deg(i,:) = 0;
         else
             exponent_p = exponents(pi,yy);

--- a/@sdpvar/display.m
+++ b/@sdpvar/display.m
@@ -72,8 +72,8 @@ switch(X.typeflag)
             if any(ismember(depends(X),yalmip('parvariables')))
                 classification = [classification ', parametric'];
             end
-            if ~isnan(double(X))
-                classification = [classification ', current value : ' num2str(double(X))];
+            if ~isnan(value(X))
+                classification = [classification ', current value : ' num2str(value(X))];
             end
             classification = [classification ')'];
 
@@ -152,7 +152,7 @@ switch(X.typeflag)
             
             if (n<100) && (n==m)
                 x = recover(xvars);
-                if ~any(any(isnan(double(x))))
+                if ~any(any(isnan(value(x))))
                     doubleX = double(X);
                     try
                     eigX = eig(doubleX);
@@ -162,8 +162,8 @@ switch(X.typeflag)
                 end
             elseif n~=m
                 x = recover(xvars);
-                if ~any(any(isnan(double(x))))
-                    doubleX = double(X);
+                if ~any(any(isnan(value(x))))
+                    doubleX = value(X);
                     try                       
                         info = [info ', values in range [' num2str(min(min(doubleX))) ',' num2str(max(max(doubleX))) ']'];
                     catch

--- a/@sdpvar/double.m
+++ b/@sdpvar/double.m
@@ -4,11 +4,13 @@ function [sys,values] = double(varargin)
 % New syntax
 switch nargout
     case 0
-        value(varargin{:})
+        double(value(varargin{:}))
     case 1
-        sys = value(varargin{:});
+        sys = double(value(varargin{:}));
     case 2
         [sys,values] = value(varargin{:});
+        sys = double(sys);
+        values = double(values);
     otherwise
         error('Too many output arguments.');
 end

--- a/@sdpvar/exclude.m
+++ b/@sdpvar/exclude.m
@@ -17,7 +17,7 @@ function F = exclude(X,Y)
 %    sol = solvesdp(Model,c'*x);
 % end
 
-if isa(X,'sdpvar') & is(X,'binary') &  isa(Y,'double') &  ismember(Y,[0 1])
+if isa(X,'sdpvar') & is(X,'binary') &  isnumeric(Y) &  ismember(Y,[0 1])
     
     if isequal(size(X),size(Y))
     else

--- a/@sdpvar/exp.m
+++ b/@sdpvar/exp.m
@@ -10,7 +10,7 @@ switch class(varargin{1})
         y = [];
         for i = 1:prod(d)
             xi = extsubsref(x,i);
-            if isa(xi,'double')
+            if isnumeric(xi)
                 y = [y;exp(xi)];
             else
                 if isreal(xi)

--- a/@sdpvar/factors.m
+++ b/@sdpvar/factors.m
@@ -9,7 +9,7 @@ end
 % Prune. 
 keep = 1:length(L);
 for i = 1:length(L)
-    if isa(M{i},'double')
+    if isnumeric(M{i})
         if nnz(M{i})==0
             keep(i) = 0;
         end

--- a/@sdpvar/horzcat.m
+++ b/@sdpvar/horzcat.m
@@ -140,7 +140,7 @@ for i = 1:length(varargin)
             y.midfactors{end+1} = varargin{i}.midfactors{j};
             y.leftfactors{end+1} = varargin{i}.leftfactors{j};
         end
-    elseif isa(varargin{i},'double')
+    elseif isnumeric(varargin{i})
         if ~all(varargin{i}==0)
             %  if ~doublehere
             here = length(y.midfactors)+1;

--- a/@sdpvar/int.m
+++ b/@sdpvar/int.m
@@ -43,6 +43,6 @@ elseif length(to) ~= length(x)
 end
 
 F = int_sdpvar(f,x,from,to);
-if isa(F,'double')
+if isnumeric(F)
     F = full(F);
 end

--- a/@sdpvar/max.m
+++ b/@sdpvar/max.m
@@ -37,7 +37,7 @@ switch nargin
             return
         elseif min(size(X))==1
             X = removeInf(X);
-            if isa(X,'double')
+            if isnumeric(X)
                 y = max(X);
             elseif length(X) == 1
                 y = X;
@@ -114,7 +114,7 @@ switch nargin
                 inparg = extsubsref(X,1:size(X,1),i);
                 if isa(inparg,'sdpvar')
                     inparg = removeInf(inparg);
-                    if  isa(inparg,'double')
+                    if  isnumeric(inparg)
                         y = [y max(inparg)];
                     elseif length(inparg) == 1
                         y = [y max(inparg)];

--- a/@sdpvar/min.m
+++ b/@sdpvar/min.m
@@ -54,7 +54,7 @@ switch nargin
             
             
             X = removeInf(X);
-            if isa(X,'double')
+            if isnumeric(X)
                 y = min(X);
             elseif length(X) == 1
                 y = X;
@@ -137,12 +137,12 @@ switch nargin
             y = [];
             for i = 1:size(X,2)
                 inparg = extsubsref(X,1:size(X,1),i);
-                if isa(inparg,'double')
+                if isnumeric(inparg)
                     y = [y min(inparg)];
                     return
                 end
                 inparg = removeInf(inparg);
-                if  isa(inparg,'double')
+                if  isnumeric(inparg)
                     y = [y min(inparg)];
                 elseif isa(inparg,'sdpvar')
                     z = yalmip('define','min_internal',inparg);

--- a/@sdpvar/minus.m
+++ b/@sdpvar/minus.m
@@ -78,7 +78,11 @@ switch 2*X_is_spdvar+Y_is_spdvar
         % Speeeeeeed
         if x_isscalar && y_isscalar
             y.basis = -y.basis;
-            y.basis(1) = y.basis(1)+X;
+            tmp = y.basis(1)+X;
+            if (isequal(class(tmp),'gem') || isequal(class(tmp),'sgem')) && ~isequal(class(y.basis), class(tmp))
+                y.basis = gemify(y.basis);
+            end
+            y.basis(1) = tmp;
             % Reset info about conic terms
             y.conicinfo = [0 0];
             y.extra.opname='';
@@ -94,7 +98,11 @@ switch 2*X_is_spdvar+Y_is_spdvar
             end
             y.basis = -y.basis;
             if nnz(X)~=0
-                y.basis(:,1) = y.basis(:,1)+X(:);
+                tmp = y.basis(:,1)+X(:);
+                if (isequal(class(tmp),'gem') || isequal(class(tmp),'sgem')) && ~isequal(class(y.basis), class(tmp))
+                    y.basis = gemify(y.basis);
+                end
+                y.basis(:,1) = tmp;
             end
         else
             error('Matrix dimensions must agree.');
@@ -130,7 +138,11 @@ switch 2*X_is_spdvar+Y_is_spdvar
 
         % Speeeeeeed
         if x_isscalar && y_isscalar
-            y.basis(1) = y.basis(1)-Y;
+            tmp = y.basis(1)-Y;
+            if (isequal(class(tmp),'gem') || isequal(class(tmp),'sgem')) && ~isequal(class(y.basis), class(tmp))
+                y.basis = gemify(y.basis);
+            end
+            y.basis(1) = tmp;
             % Reset info about conic terms
             y.conicinfo = [0 0];
             y.extra.opname='';
@@ -144,7 +156,11 @@ switch 2*X_is_spdvar+Y_is_spdvar
                 y.dim(1) = n_Y;
                 y.dim(2) = m_Y;
             end
-            y.basis(:,1) = y.basis(:,1)-Y(:);
+            tmp = y.basis(:,1)-Y(:);
+            if (isequal(class(tmp),'gem') || isequal(class(tmp),'sgem')) && ~isequal(class(y.basis), class(tmp))
+                y.basis = gemify(y.basis);
+            end
+            y.basis(:,1) = tmp;
         else
             error('Matrix dimensions must agree.');
         end

--- a/@sdpvar/mtimes.m
+++ b/@sdpvar/mtimes.m
@@ -559,7 +559,7 @@ switch 2*X_is_spdvar+Y_is_spdvar
                     return
                 end
             else
-                if ~isa(Y,'double')
+                if isa(Y,'uint8') || isa(Y,'uint16') || isa(Y,'uint32') || isa(Y,'uint64')
                     Y = double(Y);
                 end
                 Z.dim(1) = n_Y;
@@ -573,7 +573,7 @@ switch 2*X_is_spdvar+Y_is_spdvar
                 return
             end
         elseif y_isscalar
-            if ~isa(Y,'double')
+            if isa(Y,'uint8') || isa(Y,'uint16') || isa(Y,'uint32') || isa(Y,'uint64')
                 Y = double(Y);
             end
             Z.dim(1) = n_X;
@@ -594,7 +594,7 @@ switch 2*X_is_spdvar+Y_is_spdvar
             % encountered in large-scale QPs
             Z.basis = [X.basis(:,1) Y.'];
         else
-            if ~isa(Y,'double')
+            if isa(Y,'uint8') || isa(Y,'uint16') || isa(Y,'uint32') || isa(Y,'uint64')
                 Y = double(Y);
             end
             Z.basis = kron(Y.',speye(n_X))*X.basis;
@@ -678,7 +678,7 @@ switch 2*X_is_spdvar+Y_is_spdvar
             end
         else
             try
-                if ~isa(X,'double')
+                if isa(X,'uint8') || isa(X,'uint16') || isa(X,'uint32') || isa(X,'uint64')
                     X = double(X);
                 end
                 speyemy = speye(m_Y);
@@ -688,7 +688,7 @@ switch 2*X_is_spdvar+Y_is_spdvar
                 disp('Multiplication of SDPVAR object caused memory error');
                 disp('Continuing using unvectorized version which is extremely slow');
                 Z.basis = [];
-                if ~isa(X,'double')
+                if isa(X,'uint8') || isa(X,'uint16') || isa(X,'uint32') || isa(X,'uint64')
                     X = double(X);
                 end
                 for i = 1:size(Y.basis,2);

--- a/@sdpvar/ne.m
+++ b/@sdpvar/ne.m
@@ -16,7 +16,7 @@ function F = ne(X,Y)
 
 if isa(X,'sdpvar') & isa(Y,'sdpvar') & is(X,'binary') & is(Y,'binary')
     F = (X + Y == 1);
-elseif isa(X,'sdpvar') & is(X,'binary') & is(X,'lpcone') &  isa(Y,'double') &  ismember(Y,[0 1])
+elseif isa(X,'sdpvar') & is(X,'binary') & is(X,'lpcone') &  isnumeric(Y,'double') &  ismember(Y,[0 1])
     zv = find((Y == 0));
     ov = find((Y == 1));
     lhs = 0;

--- a/@sdpvar/norm.m
+++ b/@sdpvar/norm.m
@@ -60,7 +60,7 @@ switch class(varargin{1})
                         varargout{1} = yalmip('define','norm_nuclear',varargin{:});
                     end
                 otherwise
-                    if isreal(varargin{1}) & min(size(varargin{1}))==1 & isa(varargin{2},'double')
+                    if isreal(varargin{1}) & min(size(varargin{1}))==1 & isnumeric(varargin{2})
                         varargout{1} = pnorm(varargin{:});
                     else
                         error('norm(x,P) only supported for P = 1, 2, inf, ''fro'' and ''nuclear''');

--- a/@sdpvar/plus.m
+++ b/@sdpvar/plus.m
@@ -17,7 +17,7 @@ if ~X_is_spdvar
         Y.basis = intval(Y.basis);
     elseif isa(X,'uint8') || isa(X,'uint16') || isa(X,'uint32') || isa(X,'uint64')
         X = double(X);  
-    elseif ~isa(X,'double')
+    elseif ~isnumeric(X)
         error(['Cannot add SDPVAR object and ' upper(class(X)) ' object']);
     end
 end
@@ -31,7 +31,7 @@ if ~Y_is_spdvar
         X.basis = intval(X.basis);
     elseif isa(Y,'uint8') || isa(Y,'uint16') || isa(Y,'uint32') || isa(Y,'uint64')
         Y = double(Y);          
-    elseif ~isa(Y,'double')
+    elseif ~isnumeric(Y)
         error(['Cannot add SDPVAR object and ' upper(class(Y)) ' object']);
     end
 end
@@ -77,12 +77,16 @@ switch 2*X_is_spdvar+Y_is_spdvar
         any_scalar = x_isscalar | y_isscalar;
         
         if x_isscalar && y_isscalar            
-             y.basis(1) = y.basis(1)+X;
-             % Reset info about conic terms
-             y.conicinfo = [0 0];
-             y.extra.opname='';
-             y = addfactors(y,X,Y);
-             return
+            tmp = y.basis(1)+X;
+            if (isequal(class(tmp),'gem') || isequal(class(tmp),'sgem')) && ~isequal(class(y.basis), class(tmp))
+                y.basis = gemify(y.basis);
+            end
+            y.basis(1) = tmp;
+            % Reset info about conic terms
+            y.conicinfo = [0 0];
+            y.extra.opname='';
+            y = addfactors(y,X,Y);
+            return
          end
          
         if any_scalar || all([n_Y m_Y]==[n_X m_X])
@@ -91,7 +95,11 @@ switch 2*X_is_spdvar+Y_is_spdvar
                 y.dim(1) = n_X;
                 y.dim(2) = m_X;
             end
-            y.basis(:,1) = y.basis(:,1)+X(:);
+            tmp = y.basis(:,1)+X(:);
+            if (isequal(class(tmp),'gem') || isequal(class(tmp),'sgem')) && ~isequal(class(y.basis), class(tmp))
+                y.basis = gemify(y.basis);
+            end
+            y.basis(:,1) = tmp;
         else
             error('Matrix dimensions must agree.');
         end
@@ -120,7 +128,11 @@ switch 2*X_is_spdvar+Y_is_spdvar
         
          % Special special case...
          if x_isscalar && y_isscalar
-             y.basis(1) = y.basis(1)+Y;
+             tmp = y.basis(1)+Y;
+             if (isequal(class(tmp),'gem') || isequal(class(tmp),'sgem')) && ~isequal(class(y.basis), class(tmp))
+                 y.basis = gemify(y.basis);
+             end
+             y.basis(1) = tmp;
              % Reset info about conic terms
              y.conicinfo = [0 0];
              y.extra.opname='';
@@ -134,7 +146,11 @@ switch 2*X_is_spdvar+Y_is_spdvar
                 y.dim(1) = n_Y;
                 y.dim(2) = m_Y;
             end
-            y.basis(:,1) = y.basis(:,1)+Y(:);
+            tmp = y.basis(:,1)+Y(:);
+            if (isequal(class(tmp),'gem') || isequal(class(tmp),'sgem')) && ~isequal(class(y.basis), class(tmp))
+                y.basis = gemify(y.basis);
+            end
+            y.basis(:,1) = tmp;
         else
             error('Matrix dimensions must agree.');
         end

--- a/@sdpvar/power.m
+++ b/@sdpvar/power.m
@@ -39,7 +39,7 @@ else
 end
 
 % Trivial cases
-if isa(d,'double')
+if isnumeric(d)
     if all(all(d==0))
         y = ones(x.dim(1),x.dim(2));
         return

--- a/@sdpvar/rdivide.m
+++ b/@sdpvar/rdivide.m
@@ -11,7 +11,7 @@ if ~((prod(size(X))==1) | (prod(size(Y))==1))
 end
 
 % Quick exit for simple case X/scalar
-if isa(Y,'double') & prod(size(Y))==1
+if isnumeric(Y) & prod(size(Y))==1
     y = X;
     y.basis = y.basis/Y;
     % Reset info about conic terms
@@ -19,7 +19,7 @@ if isa(Y,'double') & prod(size(Y))==1
     return
 end
 
-if isa(X,'sdpvar') & isa(Y,'double')
+if isa(X,'sdpvar') & isnumeric(Y)
     y = X.*(1./Y);
     return
 end

--- a/@sdpvar/replace.m
+++ b/@sdpvar/replace.m
@@ -49,8 +49,8 @@ if isa(W,'sdpvar')
     return
 end
 
-if ~isa(W,'double')
-    error('Third arguments must be a double')
+if ~isnumeric(W)
+    error('Third arguments must be numeric')
 end
 
 % Replace with NaN   destroys everything, assume it should be cleared

--- a/@sdpvar/sos.m
+++ b/@sdpvar/sos.m
@@ -41,7 +41,7 @@ if ~is(X,'symmetric')
         I.type = '()';
         I.subs = {[i]};
         x = subsref(X,I);
-        if isa(x,'double')
+        if isnumeric(x)
             if x < 0
                 error('You are trying to enforce a negative constant to be SOS!');
             end

--- a/@sdpvar/sqrtm_internal.m
+++ b/@sdpvar/sqrtm_internal.m
@@ -3,7 +3,7 @@ function varargout = sqrtm_internal(varargin)
 
 switch class(varargin{1})
 
-    case 'double'
+    case {'double', 'gem', 'sgem'}
         varargout{1} = sqrt(varargin{1});
 
     case 'sdpvar'

--- a/@sdpvar/subsasgn.m
+++ b/@sdpvar/subsasgn.m
@@ -41,8 +41,14 @@ try
                     error(lasterr)
                 end
             case 2
-                if ~isempty(Y)                    
-                    Y = sparse(double(Y));                    
+                if ~isempty(Y)     
+                    if isa(Y,'uint8') || isa(Y,'uint16') || isa(Y,'uint32') || isa(Y,'uint64')
+                        Y = sparse(double(Y));
+                    elseif isnumeric(Y)
+                        Y = sparse(Y);
+                    else
+                        Y = sparse(double(Y));
+                    end
                 end
                 y = X;
                 

--- a/@sdpvar/subsref.m
+++ b/@sdpvar/subsref.m
@@ -65,8 +65,8 @@ try
                 end
                 if mpt_solution
                     assign(nonlinearModel{1}.arg{2},Y(1).subs{:});
-                    XX = double(X);
-                    varargout{1} = double(X);
+                    XX = value(X);
+                    varargout{1} = value(X);
                     return
                 end
             end
@@ -79,14 +79,14 @@ try
                         OldArgument = [OldArgument;  nonlinearModel.arg{i}];
                     end
                 end
-                if isa([Y.subs{:}],'double')
+                if isnumeric([Y.subs{:}])
                     assign(reshape(OldArgument,[],1),reshape([Y(1).subs{:}],[],1));
-                    varargout{1} = double(X);
+                    varargout{1} = value(X);
                     return
                 end
             end
             y = replace(X,OldArgument,[Y(1).subs{:}]);
-            if isa(y,'double')
+            if isnumeric(y)
                 varargout{1} = y;
                 return
             end
@@ -106,7 +106,7 @@ try
                                         constraints = [constraints, Y(2).subs{i}];
                                     case 'struct'
                                         options = Y(2).subs{i};
-                                    case {'double','char'}
+                                    case {'double','char','gem','sgem'}
                                         opsargs{end+1} = Y(2).subs{i};
                                     otherwise
                                         error('Argument to minimize should be constraints or options');

--- a/@sdpvar/sym.m
+++ b/@sdpvar/sym.m
@@ -25,7 +25,7 @@ function symb_pvec = sdisplay(pvec,symbolicname)
 %      'x^2+y^2+ryv(5)^2+ryv(6)^2'
 
 
-% Author Johan Löfberg
+% Author Johan Lï¿½fberg
 % $Id: sym.m,v 1.1 2005-02-22 16:50:11 johanl Exp $
 allnames = {};
 for pi = 1:size(pvec,1)
@@ -34,7 +34,7 @@ for pi = 1:size(pvec,1)
         Y.subs = [{pi} {pj}];
         p = subsref(pvec,Y);    
         
-        if isa(p,'double')
+        if isnumeric(p)
             symb_p = num2str(p);
         else
             LinearVariables = depends(p);

--- a/@sdpvar/times.m
+++ b/@sdpvar/times.m
@@ -18,12 +18,12 @@ if isa(Y,'blkvar')
     Y = sdpvar(Y);
 end
 
-if isa(X,'double')
+if isnumeric(X)
     if any(isnan(X))
         error('Multiplying NaN with an SDPVAR makes no sense.');
     end
 end
-if isa(Y,'double')
+if isnumeric(Y)
     if any(isnan(Y))
         error('Multiplying NaN with an SDPVAR makes no sense.');
     end

--- a/@sdpvar/value.m
+++ b/@sdpvar/value.m
@@ -95,7 +95,11 @@ end
 
 if nargin == 1
     % All double values
-    values=nan(size(mt,1),1);
+    if isempty(solution.optvar)
+        values=nan(size(mt,1),1);
+    else
+        values=solution.optvar(1)*nan(size(mt,1),1);
+    end
     values(solution.variables) = solution.optvar;
     clear_these = allextended;
     if yalmip('containsSemivar') && ~isempty(allStruct)

--- a/@sdpvar/vertcat.m
+++ b/@sdpvar/vertcat.m
@@ -111,7 +111,7 @@ for i = 1:length(varargin)
             y.midfactors{end+1} = varargin{i}.midfactors{j};
             y.rightfactors{end+1} = varargin{i}.rightfactors{j};
         end
-    elseif isa(varargin{i},'double')       
+    elseif isnumeric(varargin{i})
         here = length(y.midfactors)+1;
         doublehere = [doublehere here];      
         y.leftfactors{here} = [spalloc(sum(n(1:1:i-1)),size(varargin{i},1),0); speye(size(varargin{i},1)); spalloc(sum(n(i+1:1:end)),size(varargin{i},1),0)];

--- a/extras/compileinterfacedata.m
+++ b/extras/compileinterfacedata.m
@@ -1055,11 +1055,11 @@ if ~isempty(F_struc)
 end
 
 % *************************************************************************
-%% If solver doesn't support high precision input, make sure the input is
-% only double precision.
+%% Does the solver support high precision input? If not, make sure the 
+% input is only double precision.
 % *************************************************************************
 
-if ~isequal(solver.call, 'iterative_refinement')
+if solver.supportshighprec ~= 1
     if isa(F_struc, 'gem') || isa(F_struc, 'sgem')
         F_struc = double(F_struc);
     end

--- a/extras/compileinterfacedata.m
+++ b/extras/compileinterfacedata.m
@@ -1055,6 +1055,42 @@ if ~isempty(F_struc)
 end
 
 % *************************************************************************
+%% If solver doesn't support high precision input, make sure the input is
+% only double precision.
+% *************************************************************************
+
+if ~isequal(solver.call, 'iterative_refinement')
+    if isa(F_struc, 'gem') || isa(F_struc, 'sgem')
+        F_struc = double(F_struc);
+    end
+    if isa(c, 'gem') || isa(c, 'sgem')
+        c = double(c);
+    end
+    if isa(Q, 'gem') || isa(Q, 'sgem')
+        Q = double(Q);
+    end
+    if isa(f, 'gem') || isa(f, 'sgem')
+        f = double(f);
+    end
+    if isa(lb, 'gem') || isa(lb, 'sgem')
+        lb = double(lb);
+    end
+    if isa(ub, 'gem') || isa(ub, 'sgem')
+        ub = double(ub);
+    end
+    if isa(x0, 'gem') || isa(x0, 'sgem')
+        x0 = double(x0);
+    end
+    if isa(oldF_struc, 'gem') || isa(oldF_struc, 'sgem')
+        oldF_struc = double(oldF_struc);
+    end
+    if isa(oldc, 'gem') || isa(oldc, 'sgem')
+        oldc = double(oldc);
+    end
+end
+
+
+% *************************************************************************
 %% GENERAL DATA EXCHANGE WITH SOLVER
 % *************************************************************************
 interfacedata.F_struc = F_struc;

--- a/extras/createobjective.m
+++ b/extras/createobjective.m
@@ -37,9 +37,9 @@ else
         else
             % A relaxed problem should not calculate quadratic
             % decomposistion, fix!
-            c=zeros(nvars,1);
             lmi_variables = getvariables(h);
             base = getbase(h);base= base(2:end);
+            c=base(1)*zeros(nvars,1);
             c(lmi_variables) = base;
             Q = spalloc(nvars,nvars,0); 
             f = full(getbasematrix(h,0));

--- a/extras/sdpsettings.m
+++ b/extras/sdpsettings.m
@@ -569,9 +569,9 @@ refiner.maxiter = 200;
 refiner.internalSolver = '';
 refiner.refinePrimal = true;
 refiner.refineDual = true;
-refiner.solvePrimalFirst = false;
-refiner.primalInPrimalForm = false;
-refiner.dualInPrimalForm = false;
+refiner.solvePrimalFirst = true;
+refiner.primalInPrimalForm = true;
+refiner.dualInPrimalForm = true;
 
 
 function bpmpd = setup_bpmpd_options

--- a/extras/sdpsettings.m
+++ b/extras/sdpsettings.m
@@ -564,14 +564,14 @@ sos.savedecomposition = 1;
 sos.traceobj = 0;
 sos.reuse = 1;
 function refiner = setup_refiner_options
-refiner.nbDigits = 30;
+refiner.precdigits = 30;
 refiner.maxiter = 200;
-refiner.internalSolver = '';
-refiner.refinePrimal = true;
-refiner.refineDual = true;
-refiner.solvePrimalFirst = true;
-refiner.primalInPrimalForm = true;
-refiner.dualInPrimalForm = true;
+refiner.internalsolver = '';
+refiner.refineprimal = true;
+refiner.refinedual = true;
+refiner.solveprimalfirst = true;
+refiner.primalinprimalform = true;
+refiner.dualinprimalform = true;
 
 
 function bpmpd = setup_bpmpd_options

--- a/extras/sdpsettings.m
+++ b/extras/sdpsettings.m
@@ -22,7 +22,7 @@ function options = sdpsettings(varargin)
 %
 %   GENERAL
 %
-%    solver             - Specify solver [''|sdpt3|sedumi|sdpa|pensdp|penbmi|csdp|dsdp|maxdet|lmilab|cdd|cplex|xpress|mosek|nag|quadprog|linprog|bnb|bmibnb|kypd|mpt|none ('')]
+%    solver             - Specify solver [''|sdpt3|sedumi|sdpa|pensdp|penbmi|csdp|dsdp|maxdet|lmilab|cdd|cplex|xpress|mosek|nag|quadprog|linprog|bnb|bmibnb|kypd|mpt|refiner|none ('')]
 %    verbose            - Display-level [0|1|2|...(0)] (0-silent, 1-normal, >1-loud)
 %    usex0              - Use the current values obtained from double as initial iterate if solver supports that [0|1 (0)]
 %
@@ -54,6 +54,10 @@ function options = sdpsettings(varargin)
 %   BRANCH AND BOUND for polynomial programs
 %
 %    options.bmibnb, see help bmibnb
+%
+%   ITERATIVE REFINEMENT for linear programs
+%
+%    options.refiner, see help iterative_refinement
 %
 %   EXTERNAL SOLVERS
 %
@@ -113,7 +117,10 @@ else
     options.sos = setup_sos_options;
     Names = appendOptionNames(Names,options.sos,'sos');
 
-    % External solvers
+    options.refiner = setup_refiner_options;
+    Names = appendOptionNames(Names,options.refiner,'refiner');
+
+    % External solvers  
     options.baron = setup_baron_options;
     Names = appendOptionNames(Names,options.baron,'baron');
 
@@ -556,6 +563,16 @@ sos.clean = eps;
 sos.savedecomposition = 1;
 sos.traceobj = 0;
 sos.reuse = 1;
+function refiner = setup_refiner_options
+refiner.nbDigits = 30;
+refiner.maxiter = 200;
+refiner.internalSolver = '';
+refiner.refinePrimal = true;
+refiner.refineDual = true;
+refiner.solvePrimalFirst = false;
+refiner.primalInPrimalForm = false;
+refiner.dualInPrimalForm = false;
+
 
 function bpmpd = setup_bpmpd_options
 try

--- a/modules/global/iterative_refinement.m
+++ b/modules/global/iterative_refinement.m
@@ -1,0 +1,731 @@
+function output = iterative_refinement(model)
+%ITERATIVE REFINEMENT metasolver
+%
+% ITERATVE_REFINEMENT is never called by the user directly, but is called by YALMIP from
+% SOLVESDP, by choosing the solver tag 'refiner' in sdpsettings
+%
+% The behaviour of ITERATIVE_REFINEMENT can be altered using the fields in the field
+% 'refiner' in SDPSETTINGS
+%
+% refiner.nbDigits           - Solver target precision in digits [real (35)]
+% refiner.maxiter            - Maximum number of iterations [int (20)];
+% refiner.verbose            - Verbosity level [ 0|1|2 (1)];
+% refiner.internalSolver     - Internal solver [solver tag ('')]
+% refiner.refinePrimal       - Whether the primal should be refined [true|false (true)]
+% refiner.refineDual         - Whether the dual should be refined [true|false (true)]
+% refiner.solvePrimalFirst   - Whether the first iteration is done in primal or dual form [true|false (false)]
+% refiner.primalInPrimalForm - Whether the primal refinements should be solved in primal or dual form [true|false (false)]
+% refiner.dualInPrimalForm   - Whether the primal refinements should be solved in primal or dual form [true|false (false)]
+%
+% Note : In order to take achieve precisions of more than 15 digits, this
+% solver requires the high precision library GEM to be in matlab's path.
+% This library can be downloaded from https://github.com/jdbancal/gem/releases
+% Best results will be obtained by specifying the problem to be solved in
+% terms of gem or sgem variables.
+%
+% Example:
+
+% Author Jean-Daniel Bancal
+
+
+showprogress('Iterative refinement started',model.options.showprogress);
+
+% *************************************************************************
+% INITIALIZE DIAGNOSTICS AND DISPLAY LOGICS (LOWER VERBOSE IN SOLVERS)
+% *************************************************************************
+
+% Retrieve needed data
+options = model.options;
+F_struc = model.F_struc;
+c       = model.c;
+K       = model.K;
+ub      = model.ub;
+lb      = model.lb;
+
+
+% *********************************************
+% Bounded variables converted to constraints
+% N.B. Only happens when caller is BNB
+% *********************************************
+if ~isempty(ub)
+    [F_struc,K] = addStructureBounds(F_struc,K,ub,lb);
+end
+
+if options.savedebug
+    save refinerdebug F_struc c K options
+end
+
+
+% *********************************************
+% Some general checks
+% *********************************************
+
+if (options.verbose >= 2) && (options.refiner.nbDigits > 15) && ((~isa(F_struc, 'gem') && ~isa(F_struc, 'sgem')) || (~isa(c, 'gem') && ~isa(c, 'sgem')))
+    disp(' ');
+    disp('Warning: Trying to solve a problem in high precision but all coefficients don''t have a high precision.');
+    disp('         Additional zeros will be added at the end of these coefficients.');
+    disp(' ');
+end
+
+% *********************************************
+% Call the Refiner
+% *********************************************
+if options.showprogress;showprogress(['Calling ' model.solver.tag],options.showprogress);end
+
+problem = 0;
+warnState = warning;
+solvertime = tic;
+
+[fval x_s y_s z_s info] = refiner(-F_struc(:,2:end), -c, F_struc(:,1), K, options);
+y_s = -y_s;
+
+warning(warnState);
+solvertime = toc(solvertime);
+
+% Internal format
+Primal = y_s;
+Dual   = x_s;
+
+infostr = yalmiperror(info.problem,model.solver.tag);
+
+% Save ALL data sent to solver
+if options.savesolverinput
+    solverinput.A = -F_struc(:,2:end);
+    solverinput.c = F_struc(:,1);
+    solverinput.b = -c;
+    solverinput.K = K;
+    solverinput.options = options;
+else
+    solverinput = [];
+end
+
+% Save ALL data from the solution?
+if options.savesolveroutput
+    solveroutput.x = x_s;
+    solveroutput.y = y_s;
+else
+    solveroutput = [];
+end
+
+% Standard interface 
+output = createOutputStructure(Primal,Dual,[],problem,infostr,solverinput,solveroutput,solvertime);
+
+
+return;
+
+
+end
+
+
+
+function [fval x y z info] = refiner(Aeq, beq, f, K, options, l, fd, ld, beqd, Ld, xEst, yEst, zEst, beq0, l0, beqd0, Ld0, zoom)
+% [fval x y z info] = refiner(Aeq, beq, f, K, options, l, fd, ld, beqd, Ld, xEst, yEst, zEst, beq0, l0, beqd0, Ld0, zoom)
+%
+% Tries to solve the semi-definite program
+%     maximize   f'*x
+%   subject to   Aeq*x = beq
+%          and   x belongs to some self-dual homogeneous cones
+%
+% x can be a combination of scalars and matrices of various sizes, as 
+% specified by K.f, K.l and K.s (a la sedumi).
+%
+% For better results, the above parameters should be provided as gem/sgem
+% objects.
+%
+% l does not need to be specified. If specified, it sets a lower bound on
+% the bounded variables (as specified by K.l).
+% 
+% fd, ld, beqd, Ld are specifications of the dual (they should NOT be
+% provided by the user; they will be computed automatically).
+%
+% xEst, yEst, zEst are estimations of the primal and dual solutions. They 
+% should NOT be provided by the user.
+%
+% beq0, l0, beqd0, Ld0 are the initial values of beq, l, beqd and Ld. They
+% should NOT be provided manually.
+%
+% zoom is also an internal parameter.
+%
+% The output fval is the result of the optimization
+% x is the optimal primal variable
+% y and z are the optimal dual variables
+% dimacs reports the standard errors associated with the solution
+
+if false
+    %As an example, doubleLP_gem(Aeq, beq, f, K) with
+    Aeq = [1 0 1
+          -1 0 0
+           0 -1 0
+           0 -1 0
+           0 0 -1]
+    beq = [0 -1 0];
+    f = [-1 0 0 0 0]';
+    %  l = [0]'; % <--- Is this constraint really needed?
+    K.f = 1;     % <--- Take this into account (!!!)
+    K.l = 0;
+    K.s = 2;
+    %solves the following problem:
+    sedumi(Aeq, beq, -f, K)
+    %or similarly :
+    M=sdpvar(2)
+    F = [trace(M) == 1, M >= 0]
+    obj = M(1,2)
+    optimize(F, obj)
+
+    %Another example, which is a linear program:
+    Aeq = [1 0 1
+          -1 0 0
+           0 -1 0
+           0 -1 0
+           0 0 -1]
+    beq = [0 -1 0]';
+    f = [-1 0 0 0 0]';
+    %  l = [0 0 0 0]; % <--- Is this constraint really needed?
+    K.f = 1;     % <--- Take this into account (!!!)
+    K.l = 4;
+    K.s = 0;
+    % solves the following problem:
+    sedumi(Aeq, beq, -f, K)
+end
+
+% Written by Jean-Daniel Bancal on 28 January 2016
+
+%% Parameters setting
+
+persistent nbIter ops highPrecisionSupported allDimacsTot
+
+
+%% Arguments analysis and setup
+
+% First of all, we check if high precision numbers are supported
+if exist('gem','class') == 8
+    highPrecisionSupported = true;
+    
+    % We setup shortcuts to the following functions
+    gemify_f = @(x) gemify(x);
+    toStrings_f = @(x,y) toStrings(x,y);
+else
+    highPrecisionSupported = false;
+
+    % We emulate the missing functions
+    gemify_f = @(x) x;
+    toStrings_f = @(x,y) num2str(x,y);
+end
+
+% Arguments analysis
+if nargin < 18
+    % first call
+    disp('Refiner 1.0 - Iterative meta-solver');
+    tic;
+    
+    % We make sure the input is of high precision (if possible)
+    if highPrecisionSupported
+        if ~isa(Aeq, 'gem') && ~isa(Aeq, 'sgem')
+            Aeq = gemify_f(Aeq);
+        end
+        if ~isa(beq, 'gem') && ~isa(beq, 'sgem')
+            beq = gemify_f(beq);
+        end
+        if ~isa(f, 'gem') && ~isa(f, 'sgem')
+            f = gemify_f(f);
+        end
+    end
+    
+    % Initialization of the iteration process
+    nbIter = 1;
+    if highPrecisionSupported
+        zoom = gem(1);
+    else
+        zoom = 1;
+    end
+
+    % We set the initial values of the arguments
+    if size(Aeq,2)==length(beq)
+        Aeq = Aeq.';
+    end
+    
+    if highPrecisionSupported
+        l = gem(zeros(K.l,1));
+    else
+        l = zeros(K.l,1);
+    end
+
+    % We also prepare the specification of the dual program
+    fd = beq;
+    ld = l;
+    beqd = -f;
+    if highPrecisionSupported
+        Ld = gem(zeros(size(l)));
+    else
+        Ld = zeros(size(l));
+    end
+    
+    % We keep a copy of the initial arguments
+    beq0 = beq;
+    l0 = l;
+    beqd0 = beqd;
+    Ld0 = Ld;
+    
+    % We will monitor the precision improvement
+    allDimacsTot = zeros(1,6);
+else
+    nbIter = nbIter + 1;
+end
+
+
+if (nargin >= 18) && (zoom < 0)
+    % This is going to be the last iteration
+    zoom = -zoom;
+    onlyOnce = 1;
+else
+    onlyOnce = 0;
+end
+
+
+% We set the solver's parameters
+if nargin < 5
+    error('Not enough parameters');
+else
+    % We recover the parameters from the provided options
+    maxNbIter = options.refiner.maxiter;
+    verbose = options.verbose;
+    refinePrimal = options.refiner.refinePrimal;
+    refineDual = options.refiner.refineDual;
+    solvePrimalFirst = options.refiner.solvePrimalFirst;
+    primalInPrimalForm = options.refiner.primalInPrimalForm;
+    dualInPrimalForm = options.refiner.dualInPrimalForm;
+    if highPrecisionSupported
+        precision = 10^gem(-options.refiner.nbDigits);
+    else
+        precision = 10^(-options.refiner.nbDigits);
+        if (precision < 1e-15) 
+            precision = 1e-15;
+            if (nbIter == 1) && (verbose >= 1)
+                warning('No high precision library found. Precision will be limitted to 1e-15.');
+            end
+        end
+    end
+    
+    % Here are the options for the internal solver
+    if nbIter == 1
+        ops = options;
+        ops.solver = options.refiner.internalSolver;
+        ops.verbose = ops.verbose - 1;
+%        ops.solver = 'sedumi';
+%        ops.sedumi.eps = 1e-4;
+        ops.dimacs = 1; % We ask for dimacs values
+    end
+end
+
+
+% We make sure the gem default precision is larger than the required
+% precision...
+if highPrecisionSupported
+    if gemWorkingPrecision < -log10(precision)+20
+        if verbose >= 1
+            warning(['Precision of the GEM library is low (', num2str(gemWorkingPrecision), ' digits), increasing it to ', num2str(-log10(precision)+20), ' digits.']);
+        end
+        gemWorkingPrecision(-log10(precision)+20);
+    end
+end
+
+
+
+
+%% We solve the primal problem
+if ((nbIter > 1) && refinePrimal) || ((nbIter == 1) && solvePrimalFirst)
+    if primalInPrimalForm
+        if verbose >= 2
+            disp(' ');
+            disp('-- Solving the primal refinement in primal form ');
+            disp(' ');
+        end
+        % To solve the primal in primal form
+        x = sdpvar(size(f,1), 1);
+        obj = double(f)'*x;
+        F = [double(Aeq)*(x+[zeros(K.f,1); double(l)]) == double(beq), x(K.f+[1:K.l]) >= 0];
+        sol = solvesdp(F,obj,ops);
+
+        if (sol.problem ~= 0) && (sol.problem ~= 3) && (sol.problem ~= 4) && (sol.problem ~= 5)
+            % Problem is badly formulated, we come back to the previous
+            % solution...
+            nbIter = nbIter - 1;
+            fval = [];
+            x = value(x)+[zeros(1,K.f);l];
+            y = dual(F(1));
+            z = dual(F(2));
+
+            % Invert unbounded and infeasible here
+            if (sol.problem == 1) || (sol.problem == 2)
+                sol.problem = 3-sol.problem;
+            end
+            
+            info = sol;
+            return;
+        end
+        
+        % We save the result
+        xi = gemify_f(double(x))+[zeros(1,K.f);l];
+        yi = gemify_f(dual(F(1)));
+        zi = gemify_f(dual(F(2)));
+        
+        dimacsp = sol.dimacs;
+    else
+        if verbose >= 2
+            disp(' ');
+            disp('-- Solving the primal refinement in dual form ');
+            disp(' ');
+        end
+        % To solve the primal in dual form
+        ypd = sdpvar(size(beq,1),1);
+        zpd = sdpvar(size(l,1),1);
+        objpd = double(beq)'*ypd - double(l)'*zpd;
+        Fpd = [double(Aeq)'*ypd - [zeros(K.f,1); zpd] == -double(f), zpd >= 0];
+        sol = solvesdp(Fpd,objpd,ops);
+        
+        if (sol.problem ~= 0) && (sol.problem ~= 3) && (sol.problem ~= 4) && (sol.problem ~= 5)
+            % Problem is badly formulated, we come back to the previous
+            % solution...
+            nbIter = nbIter - 1;
+            fval = [];
+            x = -dual(Fpd(1));
+            y = double(ypd);
+            z = double(zpd);
+            info = sol;
+            return;
+        end
+        
+        % We save the result
+        xi = gemify_f(-dual(Fpd(1)));
+        yi = gemify_f(value(ypd));
+        zi = gemify_f(value(zpd));
+        
+        dimacsp = sol.dimacs;
+    end
+else
+    % We didn't solve the primal, so we keep neutral solutions
+    xi = zeros(size(f));
+    yi = zeros(size(beq));
+    zi = zeros(size(f));
+    dimacsp = NaN*ones(1,6);
+end
+
+
+%% Now we solve the dual independently
+if ((nbIter > 1) && refineDual) || ((nbIter == 1) && ~solvePrimalFirst)
+    if dualInPrimalForm
+        if verbose >= 2
+            disp(' ');
+            disp('-- Solving the dual refinement in primal form ');
+            disp(' ');
+        end
+        % We solve the dual in primal form (so that it coincides with the
+        % primal for the first iteration)
+
+        xdd = sdpvar(size(beqd,1), 1);
+        objdd = double(beqd)'*xdd + double(Ld)'*xdd(K.f+[1:K.l]);
+        Fdd = [double(Aeq)*(xdd+[zeros(K.f,1);double(ld)]) == double(fd), xdd(K.f+[1:K.l]) >= 0];
+        sold = solvesdp(Fdd,-objdd,ops);
+
+        if (sold.problem ~= 0) && (sold.problem ~= 3) && (sold.problem ~= 4) && (sold.problem ~= 5)
+            % Problem is badly formulated, we come back to the previous
+            % solution...
+            nbIter = nbIter - 1;
+            fval = [];
+            x = value(xdd)+[zeros(K.f,1);ld];
+            y = dual(Fdd(1));
+            z = dual(Fdd(2))+Ld;
+
+            % Invert unbounded and infeasible here
+            if (sold.problem == 1) || (sold.problem == 2)
+                sold.problem = 3-sold.problem;
+            end
+            
+            info = sold;
+            return;
+        end
+        
+        xdi = gemify_f(double(xdd))+[zeros(K.f,1);ld];
+        ydi = gemify_f(dual(Fdd(1)));
+        zdi = gemify_f(dual(Fdd(2))+Ld);
+        
+        dimacsd = sold.dimacs;
+    else
+        if verbose >= 2
+            disp(' ');
+            disp('-- Solving the dual refinement in dual form ');
+            disp(' ');
+        end
+        % Solve the dual as a dual
+        yd = sdpvar(size(fd,1),1);
+        zd = sdpvar(size(ld,1),1);
+        objd = double(fd)'*yd - double(ld)'*zd;
+        Fd = [double(Aeq)'*yd - [zeros(K.f,1); (zd + double(Ld))] == double(beqd), zd >= 0];
+        sold = solvesdp(Fd,objd,ops);
+
+        if (sold.problem ~= 0) && (sold.problem ~= 3) && (sold.problem ~= 4) && (sold.problem ~= 5)
+            % Problem is badly formulated, we come back to the previous
+            % solution...
+            nbIter = nbIter - 1;
+            fval = [];
+            x = -dual(Fd(1));
+            y = value(yd);
+            z = value(zd)+Ld;
+            info = sold;
+            return;
+        end
+        
+        % We save the result
+        ydi = gemify_f(double(yd));
+        zdi = gemify_f(double(zd))+Ld;
+        xdi = -gemify_f(dual(Fd(1)));
+        %tdi = gemify_f(dual(Fd(2))); % This is basically the same as xdi...
+
+        dimacsd = sold.dimacs;
+    end
+else
+    % We didn't solve the dual, so we keep neutral solutions
+    xdi = zeros(size(f));
+    ydi = zeros(size(beq));
+    zdi = zeros(size(f));
+    dimacsd = NaN*ones(1,6);
+end
+
+
+%% We put both solutions together
+
+% We keep the worst dimacs in memory:
+dimacs = max(abs([dimacsp; dimacsd]));
+
+if nargin < 13
+    % Then we don't have a previous estimation of the solution. The best we
+    % have is what we just obtained
+    if solvePrimalFirst
+        xTot = xi;
+        yTot = yi;
+        zTot = zi;
+
+        % We need to assign the following variables, because the dual program
+        % was not solved
+        ydi = yi;
+        zdi = zi;
+    else
+        xTot = xdi;
+        yTot = ydi;
+        zTot = zdi;
+
+        % We need to assign the following variables, because the primal program
+        % was not solved
+        xi = xdi;
+        yi = ydi;
+        zi = zdi;
+    end
+else
+    % Then we are not in the first iteration, so we take into account
+    % all previous estimations...
+    xTot = xEst + xi/zoom;
+    yTot = yEst + ydi/zoom; % The dual variables are taken from the solution of the dual program
+    zTot = zEst + zdi/zoom;
+end
+
+% Now we estimate the error for all rounds until now:
+dimacsTot = computedimacs(beq0, f, Aeq, xTot, -yTot, [], K);
+allDimacsTot(nbIter,:) = dimacsTot;
+
+if highPrecisionSupported
+    dimacsTotStr = toStrings_f(dimacsTot,5);
+    for i=1:length(dimacsTotStr)
+        dimacsTotStr{i} = [dimacsTotStr{i} '  '];
+    end
+    dimacsTotStr = [dimacsTotStr{:}];
+else
+    dimacsTotStr = num2str(dimacsTot);
+end
+
+% norm1 = @(x) max(abs(x));
+% norm2 = @(x) sqrt(sum(x.^2));
+% err1 = norm2(Aeq*xTot - beq0)/(1+norm1(beq0));
+% err2 = max([0,-min(xTot(K.f+[1:K.l])-l0)/(1+norm1(beq0))]);
+% err3 = norm2((yTot'*Aeq)' - [zeros(K.f,1);zTot] - beqd0)/(1+norm1(beqd0));
+% err4 = max([0,-min(zTot-Ld0)/(1+norm1(beqd0))]);
+% err5 = (-f'*xTot - (fd'*yTot - ld'*zTot))/(1 + abs(f'*xTot) + abs(fd'*yTot - ld'*zTot));
+% err6 = (xTot'*[zeros(K.f,1);zTot])/(1 + abs(f'*xTot) + abs(fd'*yTot - ld'*zTot));
+% dimacsTot = [err1 err2 err3 err4 err5 err6];
+
+
+%% Diagnosis
+
+% If we have enough precision, if we didn't gain enough precision at this
+% run, or if we performed too many optimizations, we stop
+if (nbIter >= maxNbIter) ...
+    || (max(abs(dimacsTot)) < precision) ...
+    || ((max(abs(dimacsTot(1:4))) < precision) && (max(abs(dimacsTot(5:6)))/max(abs(dimacsTot(1:4))) > 1e5)) ...
+    || (max(abs(dimacs)) > 1e-1) ...
+    || (onlyOnce == 1) ...
+    || (~refineDual && (max(abs(dimacsTot(1:2))) < precision)) ...
+    || (~refinePrimal && (max(abs(dimacsTot(3:4))) < precision)) ...
+    || ((nbIter >= 6) && (max(abs(allDimacsTot(end,:))./mean(abs(allDimacsTot(end-5:end-1,:)))) > 1e-1))
+
+    if verbose >= 1
+        disp(['Iteration number ', num2str(nbIter), ', ', num2str(toc), 's. Current errors : ', dimacsTotStr, '  (', num2str(max(abs(dimacsp))), ', ', num2str(max(abs(dimacsd))), ') ']);
+        disp(' ');
+    end
+
+    % We prepare the variables for the output
+    if refinePrimal && refineDual
+        % If both sides were optimized, we return both values
+        fval = [-f'*xTot (fd'*yTot - ld'*zTot)];
+    elseif refineDual
+        % If only the dual was iterated, we return the dual objective
+        % function
+        fval = (fd'*yTot - ld'*zTot);
+    else
+        % By default we return the primal objective function
+        fval = -f'*xTot;
+    end
+    x = xTot;
+    y = yTot;
+    z = zTot;
+
+    % Let's give a short summary message
+    if max(abs(dimacsTot)) <= precision
+        info.problem = 0;
+        if verbose >= 1
+            disp(['The solver achieved a precision of ', toStrings_f(max(abs(dimacsTot)),5), ' in ', num2str(nbIter), ' iterations.']);
+            disp(['Value of the objective function : ', toStrings_f(fval(1), -log10(precision))])
+        end
+    else
+        if nbIter >= maxNbIter
+            info.problem = 3;
+            if verbose >= 1
+                disp(['Iterative solver stopped after having reached the maximum number of rounds (', num2str(maxNbIter), ' iterations).']);
+                disp(['The precision of the current solution is ', toStrings_f(max(abs(dimacsTot)),5)]);
+                disp(['Current value of the objective function : ', toStrings_f(fval(1), -log10(precision))])
+            end
+        elseif (max(abs(dimacs)) > 1e-1)
+            info.problem = 5;
+            if verbose >= 1
+                disp(['Iterative solver stopped because the precision of the ', num2str(nbIter), 'th iteration is only ', num2str(max(abs(dimacs)))]);
+                disp(['The precision of the current solution is ', toStrings_f(max(abs(dimacsTot)),5)]);
+                disp(['Current value of the objective function : ', toStrings_f(fval(1) -log10(precision))])
+            end
+        elseif ((nbIter >= 6) && (max(abs(allDimacsTot(end,:))./mean(abs(allDimacsTot(end-5:end-1,:)))) > 1e-1))
+            info.problem = 5;
+            if verbose >= 1
+                disp(['Iterative solver stopped because the precision improvement over the last iterations is too small']);
+                disp(['The precision of the current solution is ', toStrings_f(max(abs(dimacsTot)),5)]);
+                disp(['Current value of the objective function : ', toStrings_f(fval(1), -log10(precision))])
+            end
+        elseif (refinePrimal && ~refineDual && max(abs(dimacsTot(1:2))) < precision)
+            info.problem = 0;
+            if verbose >= 1
+                disp(['Primal precision of ', num2str(max(abs(dimacsTot(1:2)))), ' achieved in ', num2str(nbIter), ' iterations.']);
+                disp(['Value of the objective function : ', toStrings_f(fval(1), -log10(precision))])
+            end
+        elseif (~refinePrimal && refineDual && max(abs(dimacsTot(3:4))) < precision)
+            info.problem = 0;
+            if verbose >= 1
+                disp(['Dual precision of ', num2str(max(abs(dimacsTot(3:4)))), ' achieved in ', num2str(nbIter), ' iterations.']);
+                disp(['Value of the objective function : ', toStrings_f(fval(1), -log10(precision))])
+            end
+        elseif (refinePrimal && refineDual && max(abs(dimacsTot(1:4))) < precision)
+            info.problem = 4;
+            if verbose >= 1
+                disp(['The primal and dual solutions each have a precision of ', toStrings_f(max(abs(dimacsTot(1:4))),5), ' after ', num2str(nbIter), ' iterations.']);
+                disp(['However, these solutions are only compatible up to ', toStrings_f(max(abs(dimacsTot(5:6))),5), ': the dual and primal values are respectively']);
+                if highPrecisionSupported
+                    display([fval(2); fval(1)], -log10(precision));
+                else
+                    num2str([fval(2); fval(1)], 15);
+                end
+            end
+        else
+            info.problem = 9;
+        end
+    end
+    
+    if verbose >= 1
+        disp(' ');
+    end
+    
+    return;
+end
+
+
+%% We prepare the next call
+
+% Here is our renormalization factor. It defines how many digits from the
+% primal we are ready to trust... There is at least an uncertainty of order
+% epsilon.
+if highPrecisionSupported
+    zoom2 = gem(10^(floor(log10(1/max([eps abs(dimacs)])))-1));
+else
+    zoom2 = 10^(floor(log10(1/max([eps abs(dimacs)])))-1);
+end
+
+if verbose >= 1
+    disp(['Iteration number ', num2str(nbIter), ', ', num2str(toc), 's. Current errors : ', dimacsTotStr, '  (', num2str(max(abs(dimacsp))), ', ', num2str(max(abs(dimacsd))), ') ']);
+end
+
+% If no refinement was requested, we prepare the output variables and exit.
+if (refinePrimal ~= 1) && (refineDual ~= 1)
+    fval = -f'*xTot;
+    x = xTot;
+    y = yTot;
+    z = zTot;
+    info.problem = 0;
+    if max(abs(dimacsTot)) > precision
+        info.problem = 4;
+    end
+    return;
+end
+
+
+
+factor = 1;
+nbRescaling = 0;
+zoom2 = zoom2*1;
+fval = [];
+while (nbRescaling < 10) && (zoom2 > 1) && isempty(fval)
+    nbRescaling = nbRescaling + 1;
+    if zoom2 >= 100
+        zoom2 = zoom2/10;
+    else
+        zoom2 = zoom2/2;
+    end
+    
+    % The new primal :
+    f2 = f;
+    beq2 = zoom2*(beq-Aeq*xi);
+    l2 = max([-factor*ones(size(l)), zoom2*(l-xi(K.f+[1:K.l]))],[],2);
+
+    % The new dual :
+    fd2 = fd;
+    ld2 = ld;
+    beqd2 = zoom2*(beqd-(ydi'*Aeq)'+[zeros(K.f,1);zdi]);
+    Ld2 = max([-factor*ones(size(Ld)), zoom2*(Ld-zdi)],[],2);
+
+    % We solve these new problems
+    [fval, x, y, z, info] = refiner(Aeq, beq2, f2, K, options, l2, fd2, ld2, beqd2, Ld2, xTot, yTot, zTot, beq0, l0, beqd0, Ld0, zoom*zoom2);
+
+    % If the result is empty, this means that there was a problem in the 
+    % following iteration. So we try to rescale by a smaller factor...
+    % If this doesn't work for a few times, we abort
+    if isempty(fval) && (verbose >= 1)
+        disp(['Rescaled problem appears to be badly conditioned for zoom = 10^', num2str(double(log10(zoom2))), ', trying again with a smaller zoom factor.']);
+    end
+end
+
+
+if isempty(fval)
+    % If we arrive here, we encountered numerical problems
+    x = xTot;
+    y = yTot;
+    z = zTot;
+    info = [];
+    info.problem = 4;
+end
+
+return;
+
+end

--- a/modules/global/iterative_refinement.m
+++ b/modules/global/iterative_refinement.m
@@ -180,7 +180,9 @@ end
 % Arguments analysis
 if nargin < 18
     % first call
-    disp('Refiner 1.0 - Iterative meta-solver');
+    if options.verbose >= 1
+        disp('Refiner 1.0 - Iterative meta-solver');
+    end
     tic;
     
     % We make sure the input is of high precision (if possible)
@@ -275,7 +277,7 @@ else
     if nbIter == 1
         ops = options;
         ops.solver = options.refiner.internalSolver;
-        ops.verbose = ops.verbose - 1;
+        ops.verbose = max(0, ops.verbose - 1);
 %        ops.solver = 'sedumi';
 %        ops.sedumi.eps = 1e-4;
         ops.dimacs = 1; % We ask for dimacs values

--- a/operators/pnorm.m
+++ b/operators/pnorm.m
@@ -13,7 +13,7 @@ function varargout = pnorm(varargin)
 
 switch class(varargin{1})
     
-    case 'double'
+    case {'double', 'gem', 'sgem'}
         varargout{1} = sum(varargin{1}.^varargin{2}).^(1/varargin{2});
         
     case 'sdpvar' % Overloaded operator for SDPVAR objects. Pass on args and save them.

--- a/solvers/definesolvers.m
+++ b/solvers/definesolvers.m
@@ -14,6 +14,7 @@ emptysolver.show    = 1;
 emptysolver.usesother = 0;
 emptysolver.supportsinitial = 0;
 emptysolver.supportsinitialNAN = 0;
+emptysolver.supportshighprec = 0;
 
 emptysolver.objective.linear = 0;
 emptysolver.objective.quadratic.convex = 0;
@@ -1772,4 +1773,5 @@ solver(i).tag     = 'REFINER';
 solver(i).version = '1.0';
 solver(i).checkfor= {'iterative_refinement'};
 solver(i).call    = 'iterative_refinement';
+solver(i).supportshighprec = 1;
 i = i+1;

--- a/solvers/definesolvers.m
+++ b/solvers/definesolvers.m
@@ -1766,3 +1766,10 @@ solver(i).constraint.equalities.linear = 1;
 solver(i).constraint.inequalities.secondordercone.linear = 1;
 solver(i).constraint.inequalities.rotatedsecondordercone = 0;
 i = i+1;
+
+solver(i) = lpsolver;
+solver(i).tag     = 'REFINER';
+solver(i).version = '1.0';
+solver(i).checkfor= {'iterative_refinement'};
+solver(i).call    = 'iterative_refinement';
+i = i+1;


### PR DESCRIPTION
Hi @johanlofberg,

As discussed a few days ago, please find here a pull request concerning a new high precision solver for yalmip. I try to give you below an overview of the changes that are included in this pull request, so the message is maybe slightly long... Sorry, there are just too many things to mention. In case you still have any additional question/remark, please let me know!

So maybe the first this to say is that this linear programming solver is actually more of a meta-solver, in that it constructs a high precision solution by repetitively calling a 'regular' solver. In fact, for this reason yalmip seems to be the perfect environment for such metasolver (e.g. it is easy to run it with the various internal solvers by using the yalmip interface).

Since this solver is purely written in matlab code, I though that it was more similar to other meta-solver like `bmibnb` than to `sedumi` for instance. So instead of writing a `callrefiner.m` function, I simply placed its main function `iterative_refinement.m` in the folder `modules/global`.

The solver can be used as is to increase the precision provided by a solver. Like in the following example:

    A = rand(15,5);
    x = sdpvar(5,1);
    b = rand(15,1);
    optimize([A*x>=b], sum(x), sdpsettings('solver', 'refiner', 'verbose', 1, 'refiner.precdigits', 14, 'refiner.internalsolver', 'sedumi', 'sedumi.eps', 1e-5))

However, I guess that one is not often going to reduce artificially the precision of a solver like in this example ;-P So this metasolver is more relevant for the situation in which one is interested in obtaining a solution with more than 15 digits of precision. Since this requires dealing with numbers of a different type than `doubles`, I had to make changes in a number of file (mostly in the class `sdpvar`). Each time the changes are quite small, however. Here I just give you a quick overview of the main changes.

One point I had to solve is to distinguish the usages of the keyword `double` as either:
 - Appearing in a test to tell whether we are dealing with a number or a variable (e.g. an sdpvar). For these cases I replaced `isa(x,'double')` by `isnumeric(x)`, which distinguishes numbers from variables irrespective of their precision.
 - A method for extracting the numeric value of a variable, as in `double(variable)`. For this I replaced `double` by `value`, which seems to be the preferred method for this task.

Other changes were needed to guarantee that a*x yields the same result as x'*a' if x is an sdpvar and a is a high precision number.

With these adaptations in the yalmip code, the internal coefficient representation now adjusts automatically to what the user provides: if he specifies an optimization problem with double coefficients (or logicals and integers), the coefficients are stored internally as doubles. If the user specifies an optimization problem with some high precision coefficients, these higher precision coefficients are not truncated to doubles, but stored internally in high precision form.

The one downside of this approach is that after solving a problem in high precision, the internal variables of yalmip remain in high precision for the next computations. This can lead to a slower execution of this next computation (high precision operations are always slower than double precisions). However, it is also easy to overcome this limitation by calling `yalmip clear`; one just needs to be aware of this phenomenon.

So those are the main changes to the yalmip code that you'll find in this request.

Concerning the numbers with a higher precision than doubles, you may know that matlab has its own `vpa` type which can be used for that. However, I tried to use it and it is really not efficient. Some functions, such as taking the max of a vector, or converting these number to double precision, can be extremely slow. It seems that this type of data is not well suited for purely numeric computations. Hence I looked for an alternative, but couldn't find one solution which would be at the same time open source (or at least free for academics, say), decently efficient and could deal with sparse matrices. Therefore, I wrote one such open source library ( https://www.github.com/jdbancal/gem ). The code in this pull request was tested for high precision with this library.

While I had to include some instructions tailored for this particular data type in some locations, I tried to make changes in the core yalmip code as independent as possible from this particular library. This way, it should be easy to extend it to other high precision data types if desired.

When a user has this high precision library in his matlab path, he can simply call 

    gemWorkingPrecision(220);
    A = rand(15,5);
    x = sdpvar(5,1);
    b = rand(15,1);
    optimize([A*x>=b], sum(x), sdpsettings('solver', 'refiner', 'verbose', 1, 'refiner.precdigits', 200))

and obtain a solution to this linear program with 200 digits of precision.


