### PR TITLE
Adding 'nonzeros' method

### DIFF
--- a/@sdpvar/nonzeros.m
+++ b/@sdpvar/nonzeros.m
@@ -1,0 +1,9 @@
+function y = nonzeros(x)
+    y = x;
+    b = x.basis;
+    f = find(sum(b~=0,2));
+    b = b(f,:);
+    y.basis = [b];
+    y.dim(1) = length(f);
+    y.dim(2) = 1;
+end


### PR DESCRIPTION
Attempt at a `nonzeros` method on `sdpvar` that behaves like the builtin-matlab one for (sparse) matrices.