### PR TITLE
Adjustment for compatibility with latest class precedence convention

### DIFF
--- a/@sdpvar/sdpvar.m
+++ b/@sdpvar/sdpvar.m
@@ -50,6 +50,8 @@ global FACTORTRACKING
 FACTORTRACKING = 0;
 
 superiorto('double');
+superiorto('gem');
+superiorto('sgem');
 if nargin==0
     sys = sdpvar(1,1);
     return


### PR DESCRIPTION
Previously, I used the function "inferiorto" inside the gem library to tell matlab that an sdpvar is a more elaborated object than high precision numbers, but this is not possible anymore with the latest matlab versions. Now, it seems that the more general class must tell that it should take precedence over the more basic ones, using either the "superiorto" function, or the "InferiorClass" attribute, hence the change here. The corresponding gem release is 1.0.1.