### PR TITLE
Revert "Adjustment for compatibility with latest class precedence convention"

### DIFF
--- a/@sdpvar/sdpvar.m
+++ b/@sdpvar/sdpvar.m
@@ -50,8 +50,6 @@ global FACTORTRACKING
 FACTORTRACKING = 0;
 
 superiorto('double');
-superiorto('gem');
-superiorto('sgem');
 if nargin==0
     sys = sdpvar(1,1);
     return


### PR DESCRIPTION
Reverts yalmip/YALMIP#466

Fails if there is no class 'gem'