### PR TITLE
Fix out of memory errors for OSQP and large QPs

### DIFF
--- a/solvers/callosqp.m
+++ b/solvers/callosqp.m
@@ -13,7 +13,7 @@ if options.showprogress;showprogress(['Calling ' interfacedata.solver.tag],optio
 n_var = length(model.c);
 P = model.Q;
 q = model.c;
-eye_n = eye(n_var);
+eye_n = speye(n_var);
 A = [model.Aeq;model.A; eye_n];
 l = full([model.beq; -inf(length(model.b),1); model.lb]);
 u = full([model.beq; model.b; model.ub]);


### PR DESCRIPTION
Matlab was giving out of memory error for moderate dimensions (n = 3e4, m=6e4). This was because the constraints identity matrix was allocated as dense. This small fix should avoid the problem.