### PR TITLE
Fix function name to match filename in @sdpvar/findelements.m

### DIFF
--- a/@sdpvar/findelements.m
+++ b/@sdpvar/findelements.m
@@ -1,4 +1,4 @@
-function indicies = find(x)
+function indicies = findelements(x)
 base = x.basis;
 vars = x.lmi_variables;
 indicies = find(any(base,2));


### PR DESCRIPTION
Thanks to Octave for this one, which unlike MATLAB, very helpfully warns when a function name does not match the filename.