### PR TITLE
Add an option options.scs.gpu = {false (default), true}

### DIFF
--- a/extras/sdpsettings.m
+++ b/extras/sdpsettings.m
@@ -1189,6 +1189,7 @@ scs.normalize = 1;
 scs.scale = 5;
 scs.cg_rate = 2;
 scs.eliminateequalities = 0;
+scs.gpu = false;
 
 function dsdp = setup_dsdp_options
 try

--- a/solvers/callscs.m
+++ b/solvers/callscs.m
@@ -80,7 +80,11 @@ switch  model.solver.tag
     case 'scs-direct'
          [x_s,y_s,s,info] = scs_direct(data,cones,params);
     otherwise
-        [x_s,y_s,s,info] = scs_indirect(data,cones,params);
+        if params.gpu == true
+            [x_s,y_s,s,info] = scs_gpu(data,cones,params);
+        else
+            [x_s,y_s,s,info] = scs_indirect(data,cones,params);
+        end
 end
 solvertime = toc(t);
 


### PR DESCRIPTION
Add an option options.scs.gpu = {false (default), true} to the solver scs-indirect so that the user can use scs_gpu instead of scs_indirect.
The function scs_gpu of
https://github.com/bodono/scs-matlab
calls an indirect solver of SCS that runs on GPU.