### PR TITLE
Option to directly save MOSEK task file

### DIFF
--- a/extras/sdpsettings.m
+++ b/extras/sdpsettings.m
@@ -423,6 +423,7 @@ options.allownonconvex = 1;
 options.shift = 0;
 options.dimacs = 0;
 options.beeponproblem = [-5 -4 -3 -2 -1];
+options.mosektaskfile = '';
 
 function bisection = setup_bisection_options
 bisection.absgaptol = 1e-5;

--- a/solvers/call_mosek_dual.m
+++ b/solvers/call_mosek_dual.m
@@ -52,6 +52,10 @@ if model.options.savedebug
     save mosekdebug prob param
 end
 
+if model.options.mosektaskfile
+    mosekopt(sprintf('min write(%s) echo(0)', model.options.mosektaskfile), prob, param);
+end
+
 [r,res,solvertime] = doCall(prob,param,model.options);
 
 try

--- a/solvers/call_mosek_primal.m
+++ b/solvers/call_mosek_primal.m
@@ -148,6 +148,10 @@ if model.options.savedebug
     save mosekdebug prob param
 end
 
+if model.options.mosektaskfile
+    mosekopt(sprintf('min write(%s) echo(0)', model.options.mosektaskfile), prob, param);
+end
+
 % Call MOSEK
 showprogress('Calling MOSEK',model.options.showprogress);
 if model.options.verbose == 0


### PR DESCRIPTION
We (at MOSEK) would appreciate having an option to directly save a MOSEK task file bypassing the mosekdebug.mat, considering the (increasing) number of simultaneous YALMIP+MOSEK users coming up with questions in various places.

I am sorry this pollutes the global options namespace but it is the best way I could come up with. There is unfortunately no ``MSK_SPAR...`` parameter to specify the filename to save to for security reasons so using ``model.options.mosek.*`` is not really an option unless in a very hacky way. It is up to you to reject/accept/change this as you feel like. 

Example usage:

``sdpsettings('mosektaskfile', 'dump.task.gz')``

Thanks for consideration.

Michał