### PR TITLE
Adding support for two more standard usages of 'sum' function

### DIFF
--- a/@sdpvar/sum.m
+++ b/@sdpvar/sum.m
@@ -9,6 +9,11 @@ if length(X.dim)==2
         Y = ones(1,max(X.dim))*reshape(X,[],1);
         return
     end
+    if isequal(sort(I), [1 2]) || isequal(I, 'all')
+        % special case if we sum all elements
+        Y = ones(1,X.dim(1))*X*ones(X.dim(2),1);
+        return
+    end
     switch I
         case 1
             Y = ones(1,X.dim(1))*X;

--- a/extras/@ndsdpvar/sum.m
+++ b/extras/@ndsdpvar/sum.m
@@ -18,8 +18,14 @@ else
         end
     else
         index = varargin{2};
+        if isequal(index, 'all')
+            index = 1:length(X.dim);
+        end
         if length(index) > 1
-            error('Dimension argument must be a positive integer scalar within indexing range.');
+            for i = 1:length(index)
+                X = sum(X, index(i));
+            end
+            return;
         end
     end
     if index > length(X.dim)


### PR DESCRIPTION
Following a remark from a colleague, it is quite common to use one of the following command to sum several dimensions of a matrix/tensor:
```
sum(x, [1 2]) % sums x over the first two indices
sum(x, 'all') % sums all elements in x, returning a scalar
```
Especially so with multi-dimensional object, as in:
```
xx = sdpvar(2,2,2,2);
sum(xx, [2 3]) % should return an object of size 2x1x1x2
```
Here is an attempt to include this functionality (with no aim at efficiency, only correctness).