### PR TITLE
Revert "replace strmatch() with find(strcmp()) and findstr() with strfind()"

### DIFF
--- a/@sdpvar/sdpvar.m
+++ b/@sdpvar/sdpvar.m
@@ -110,8 +110,8 @@ if ischar(varargin{1})
             varnames = varargin;
             for k = 1:n
                 varcmd{k}='(1,1)';
-                lp=strfind(varargin{k},'(');
-                rp=strfind(varargin{k},')');
+                lp=findstr(varargin{k},'(');
+                rp=findstr(varargin{k},')');
                 if isempty(lp) && isempty(rp)
                     if ~isvarname(varargin{k})
                         error('Not a valid variable name.')
@@ -224,7 +224,7 @@ switch nargin
                     error('Fourth argument should be ''complex'' or ''real''')
                 end
             end
-            index_cmrl = find(strcmp(varargin{4},{'real','complex'}));
+            index_cmrl = strmatch(varargin{4},{'real','complex'});
             if isempty(index_cmrl)
                 error('Fourth argument should be ''complex'' or ''real''. See help above')
             end
@@ -243,11 +243,11 @@ switch nargin
                 index_type = 4;
             end
         else
-            if ~isempty(find(strcmp(varargin{3},{'complex','real'})))
+            if ~isempty(strmatch(varargin{3},{'complex','real'}))
                 % User had third argument as complex or real
                 error(['Third argument should be ''symmetric'', ''full'', ''toeplitz''... Maybe you meant sdpvar(n,n,''full'',''' varargin{3} ''')'])
             end
-            index_type = find(strcmp(varargin{3},{'toeplitz','hankel','symmetric','full','rhankel','skew','hermitian','diagonal'}));
+            index_type = strmatch(varargin{3},{'toeplitz','hankel','symmetric','full','rhankel','skew','hermitian','diagonal'});
         end
 
         if isempty(index_type)

--- a/extras/@ncvar/ncvar.m
+++ b/extras/@ncvar/ncvar.m
@@ -76,8 +76,8 @@ if ischar(varargin{1})
             varnames = varargin;
             for k = 1:n
                 varcmd{k}='(1,1)';
-                lp=strfind(varargin{k},'(');
-                rp=strfind(varargin{k},')');
+                lp=findstr(varargin{k},'(');
+                rp=findstr(varargin{k},')');
                 if isempty(lp) & isempty(rp)
                     if ~isvarname(varargin{k})
                         error('Not a valid variable name.')
@@ -186,7 +186,7 @@ switch nargin
                     error('Fourth argument should be ''complex'' or ''real''')
                 end
             end
-            index_cmrl = find(strcmp(varargin{4},{'real','complex'}));
+            index_cmrl = strmatch(varargin{4},{'real','complex'});
             if isempty(index_cmrl)
                 error('Fourth argument should be ''complex'' or ''real''. See help above')
             end
@@ -205,11 +205,11 @@ switch nargin
                 index_type = 4;
             end
         else
-            if ~isempty(find(strcmp(varargin{3},{'complex','real'})))
+            if ~isempty(strmatch(varargin{3},{'complex','real'}))
                 % User had third argument as complex or real
                 error(['Third argument should be ''symmetric'', ''full'', ''toeplitz''... Maybe you meant sdpvar(n,n,''full'',''' varargin{3} ''')'])
             end
-            index_type = find(strcmp(varargin{3},{'toeplitz','hankel','symmetric','full','rhankel','skew','hermitian'}));
+            index_type = strmatch(varargin{3},{'toeplitz','hankel','symmetric','full','rhankel','skew','hermitian'});
         end
 
         if isempty(index_type)

--- a/extras/@ndsdpvar/ndsdpvar.m
+++ b/extras/@ndsdpvar/ndsdpvar.m
@@ -28,7 +28,7 @@ n = [varargin{1:d}];
 
 if nargin > d
     type = varargin{d+1};
-    if n(1)~=n(2) & ~isempty(find(strcmp(type,'symmetric')))
+    if n(1)~=n(2) & ~isempty(strmatch(type,'symmetric'))
         error('non-square matrix cannot be symmetric');
     end
 else

--- a/extras/compileinterfacedata.m
+++ b/extras/compileinterfacedata.m
@@ -200,7 +200,7 @@ if isempty(solvers)
         diagnostic.info = yalmiperror(-3,'YALMIP');
         diagnostic.problem = -3;
     end
-    if warningon & options.warning & isempty(strfind(diagnostic.info,'No problems detected'))
+    if warningon & options.warning & isempty(findstr(diagnostic.info,'No problems detected'))
         disp(['Warning: ' diagnostic.info]);
     end
     return
@@ -364,7 +364,7 @@ if strcmpi(solver.tag,'bnb')
     end 
 end
 
-if strfind(lower(solver.tag),'sparsecolo')
+if findstr(lower(solver.tag),'sparsecolo')
     temp_options = options;
     temp_options.solver = options.sparsecolo.SDPsolver;
     tempProblemClass = ProblemClass;   
@@ -378,7 +378,7 @@ if strfind(lower(solver.tag),'sparsecolo')
     solver.sdpsolver = localsolver;
 end
 
-if strfind(lower(solver.tag),'frlib')
+if findstr(lower(solver.tag),'frlib')
     temp_options = options;
     temp_options.solver = options.frlib.solver;
     tempProblemClass = ProblemClass;   
@@ -462,7 +462,7 @@ end
 % *************************************************************************
 %% DID WE SELECT THE VSDP SOLVER? Define a solver for VSDP to use
 % *************************************************************************
-if strfind(solver.tag,'VSDP')
+if findstr(solver.tag,'VSDP')
     temp_options = options;
     temp_options.solver = options.vsdp.solver;
     tempProblemClass = ProblemClass;

--- a/extras/gams2yalmip.m
+++ b/extras/gams2yalmip.m
@@ -419,7 +419,7 @@ while (feof(dataFID)==0) & (flowCTRL== 0)
             end
             % Kojima 11/06/04; to meet MATLAB 5.2
             %            temp = strfind(inputLine,';');
-            temp = strfind(inputLine,';');
+            temp = findstr(inputLine,';');
             if isempty(temp) == 0
                 flowCTRL=1;
             end

--- a/extras/parseLMI.m
+++ b/extras/parseLMI.m
@@ -6,14 +6,14 @@ function sdpvarExpr = parseLMI(X)
 % TypeofConstraint = 1;
 
 % Check for obsolete notation .<, .>, =
-single_equality = strfind(X,'=');
-if isempty(strfind(X,'>=')) & isempty(strfind(X,'<=')) & (rem(length(single_equality),2) == 1) % There is a single =    
+single_equality = findstr(X,'=');
+if isempty(findstr(X,'>=')) & isempty(findstr(X,'<=')) & (rem(length(single_equality),2) == 1) % There is a single =    
     error('Obsolete constraint =, use == in equalities.');
     %X = strrep(X,'=','==');
     %X = strrep(X,'====','=='); % Whoops, == replaced with =====!
 end
 
-if ~isempty(strfind(X,'.<'))
+if ~isempty(findstr(X,'.<'))
     disp(' ');
     disp('Warning: Obsolete constraint .<, use < in equalities.');
     disp('If you have a Hermitian matrix which you want to')
@@ -23,7 +23,7 @@ if ~isempty(strfind(X,'.<'))
     X = strrep(X,'.<','<');
 end
 
-if ~isempty(strfind(X,'.>'))
+if ~isempty(findstr(X,'.>'))
     disp(' ');
     disp('Warning: Obsolete constraint .>, use > in equalities.');
     disp('If you have a Hermitian matrix which you want to')
@@ -34,7 +34,7 @@ if ~isempty(strfind(X,'.>'))
 end
 
 % Any norm? If not, we're done!
-if isempty(strfind(X,'||'))
+if isempty(findstr(X,'||'))
     sdpvarExpr = X;
     return
 end
@@ -45,7 +45,7 @@ delimiters = {'.<','.>','<.','>.','<','>','==',''};
 delindex = 0;indtodel = [];
 while isempty(indtodel) & (delindex<=7)
     delindex = delindex+1;
-    indtodel = strfind(X,delimiters{delindex});
+    indtodel = findstr(X,delimiters{delindex});
 end
 
 switch delindex
@@ -80,8 +80,8 @@ if REVERSE
 end
 
 % Search for a norm expression
-ind_norm_Right = strfind(RightHand,'||');
-ind_norm_Left  = strfind(LeftHand,'||');
+ind_norm_Right = findstr(RightHand,'||');
+ind_norm_Left  = findstr(LeftHand,'||');
 
 % Any norm at all, if not, we're done!
 if isempty(ind_norm_Right) & isempty(ind_norm_Left)

--- a/extras/saveampl.m
+++ b/extras/saveampl.m
@@ -93,7 +93,7 @@ if nargin<3
         return % User cancelled
     else
         % Did the user change the extension
-        if isempty(strfind(filename,'.'))
+        if isempty(findstr(filename,'.'))
             filename = [pathname filename '.mod'];
         else
             filename = [pathname filename];

--- a/extras/savecplexlp.m
+++ b/extras/savecplexlp.m
@@ -44,7 +44,7 @@ if nargin<3
         return % User cancelled
     else
         % Did the user change the extension
-        if isempty(strfind(filename,'.'))
+        if isempty(findstr(filename,'.'))
             filename = [pathname filename '.lp'];
         else
             filename = [pathname filename];

--- a/extras/savesdpafile.m
+++ b/extras/savesdpafile.m
@@ -110,7 +110,7 @@ if nargin<3
 		return % User canceled
 	else
 		% Did the user change the extension
-		if isempty(strfind(filename,'.'))
+		if isempty(findstr(filename,'.'))
 			filename = [pathname filename '.dat-s'];
 		else
 			filename = [pathname filename];

--- a/extras/sdpsettings.m
+++ b/extras/sdpsettings.m
@@ -300,12 +300,12 @@ while i <= nargin
 
         lowArg = strtrim(lower(arg));
 
-        j = find(strcmp(lowArg,names));
+        j = strmatch(lowArg,names);
         if isempty(j)                       % if no matches
             error(sprintf('Unrecognized property name ''%s''.', arg));
         elseif length(j) > 1                % if more than one match
             % Check for any exact matches (in case any names are subsets of others)
-            k = find(strcmp(lowArg,names,'exact'));
+            k = strmatch(lowArg,names,'exact');
             if (length(k) == 1)
                 j = k;
             else

--- a/extras/selectsolver.m
+++ b/extras/selectsolver.m
@@ -19,7 +19,7 @@ end
 % Maybe the user is stubborn and wants to pick solver
 % ***************************************************
 forced_choice = 0;
-if length(options.solver)>0 & isempty(strfind(options.solver,'*'))
+if length(options.solver)>0 & isempty(findstr(options.solver,'*'))
     
     if strfind(options.solver,'+')
         forced_choice = 1;
@@ -29,7 +29,7 @@ if length(options.solver)>0 & isempty(strfind(options.solver,'*'))
     temp = expandSolverName(solvers);  
     
     opsolver = lower(options.solver);
-    splits = strfind(opsolver,',');
+    splits = findstr(opsolver,',');
     if isempty(splits)
         names{1} = opsolver;
     else
@@ -448,7 +448,7 @@ else
 
         % FIX : Re-use from above
         opsolver = lower(options.solver);
-        splits = strfind(opsolver,',');
+        splits = findstr(opsolver,',');
         if isempty(splits)
             names{1} = opsolver;
         else

--- a/extras/solvesdp.m
+++ b/extras/solvesdp.m
@@ -438,7 +438,7 @@ if interfacedata.options.saveyalmipmodel
     diagnostic.yalmipmodel = interfacedata;
 end
 
-if options.warning & warningon & isempty(strfind(diagnostic.info,'No problems detected'))
+if options.warning & warningon & isempty(findstr(diagnostic.info,'No problems detected'))
     disp(['Warning: ' output.infostr]);
 end
 

--- a/extras/solvesdp_multiple.m
+++ b/extras/solvesdp_multiple.m
@@ -122,7 +122,7 @@ for i = 1:length(h)
         diagnostic.yalmipmodel = model;
     end
     
-    if ops.warning && warningon && isempty(strfind(output.infostr,'No problems detected'))
+    if ops.warning && warningon && isempty(findstr(output.infostr,'No problems detected'))
         disp(['Warning: ' output.infostr]);
     end
     

--- a/solvers/callsedumi.m
+++ b/solvers/callsedumi.m
@@ -40,7 +40,7 @@ solvertime = tic;
 try
     [x_s,y_s,info] = sedumi(-F_struc(:,2:end),-c,F_struc(:,1),K,pars);
 catch
-    if strfind(lasterr,'Out of memory')
+    if findstr(lasterr,'Out of memory')
         error(lasterr)
     end
     try


### PR DESCRIPTION
Reverts yalmip/YALMIP#673

Turns out it fails in regression tests. Creation of sdpvars supports completion of arguments, which fails now

```
>> sdpvar(4,3,'fu','co')
Error using sdpvar (line 229)
Fourth argument should be 'complex' or 'real'. See help above 
```