### PR TITLE
Update yalmip2gurobi.m

### DIFF
--- a/solvers/yalmip2gurobi.m
+++ b/solvers/yalmip2gurobi.m
@@ -167,7 +167,7 @@ if ~isequal(K.q,0)
         n = K.q(i);      
         Qi = sparse(top:top+n-1,top:top+n-1,[-1 repmat(1,1,n-1)],length(c),length(c));
         model.quadcon(i).Qc=Qi;       
-        model.quadcon(i).q=zeros(length(c),1);
+        model.quadcon(i).q=sparse(zeros(length(c),1));
         model.quadcon(i).rhs=0;
         top = top + n;
     end
@@ -270,4 +270,4 @@ model.NegativeSemiVar=NegativeSemiVar;
 
 if isfield(model,'quadcon') && isempty(model.quadcon)
 	model = rmfield(model,'quadcon');
-end    
+end

--- a/solvers/yalmip2gurobi.m
+++ b/solvers/yalmip2gurobi.m
@@ -167,7 +167,7 @@ if ~isequal(K.q,0)
         n = K.q(i);      
         Qi = sparse(top:top+n-1,top:top+n-1,[-1 repmat(1,1,n-1)],length(c),length(c));
         model.quadcon(i).Qc=Qi;       
-        model.quadcon(i).q=sparse(zeros(length(c),1));
+        model.quadcon(i).q=sparse(length(c),1);
         model.quadcon(i).rhs=0;
         top = top + n;
     end


### PR DESCRIPTION
For (very) large SOCP problems, the yalmip2gurobi can crash MATLAB. Added a sparse( .. ) to avoid this issue in some cases. 