### PR TITLE
Gem avoid caught error

### DIFF
--- a/@sdpvar/sdpvar.m
+++ b/@sdpvar/sdpvar.m
@@ -46,11 +46,13 @@ function sys = sdpvar(varargin)
 %   See also INTVAR, BINVAR, methods('sdpvar'), SEE
 
 superiorto('double');
-try 
+if exist('gem')
+try
  superiorto('sgem');
  superiorto('gem');
 catch
- % GEM not in path
+ % Problem with GEM
+end
 end
 if nargin==0
     sys = sdpvar(1,1);

--- a/@sdpvar/sdpvar.m
+++ b/@sdpvar/sdpvar.m
@@ -46,13 +46,13 @@ function sys = sdpvar(varargin)
 %   See also INTVAR, BINVAR, methods('sdpvar'), SEE
 
 superiorto('double');
-if exist('gem')
-try
- superiorto('sgem');
- superiorto('gem');
-catch
- % Problem with GEM
-end
+if yalmip('gemInPath')
+    try 
+        superiorto('sgem');
+        superiorto('gem');
+    catch
+        % Problem with GEM
+    end
 end
 if nargin==0
     sys = sdpvar(1,1);

--- a/extras/yalmip.m
+++ b/extras/yalmip.m
@@ -744,6 +744,8 @@ switch varargin{1}
 		
 		internal_sdpvarstate.containsSemivar = false;
         
+        gemInPath('clear');
+        
     case 'cleardual'
         if nargin==1
             internal_setstate.duals_index = [];
@@ -1255,6 +1257,10 @@ switch varargin{1}
 		
 	case 'containsSemivar'
 		varargout = {internal_sdpvarstate.containsSemivar};
+    
+    case 'gemInPath'
+        varargout{1} = gemInPath;
+    
     otherwise
         if isa(varargin{1},'char')
             disp(['The command ''' varargin{1} ''' is not valid in YALMIP.m']);
@@ -1263,30 +1269,55 @@ switch varargin{1}
         end
 end
 
+end
+
 function h = create_vecisdouble(x)
-B = getbase(x);
-h = ~any(B(:,2:end),2);
+    B = getbase(x);
+    h = ~any(B(:,2:end),2);
+end
 
 function h = create_trivial_hash(x)
-try
-    h = sum(getvariables(x)) + sum(sum(getbase(x)));
-catch
-    h = 0;
+    try
+        h = sum(getvariables(x)) + sum(sum(getbase(x)));
+    catch
+        h = 0;
+    end
 end
 
 function h = create_trivial_vechash(x)
-try
-    B = getbase(x);
-    h = sum(B')'+(B | B)*[0;getvariables(x)'];    
-catch
-    h = 0;
+    try
+        B = getbase(x);
+        h = sum(B')'+(B | B)*[0;getvariables(x)'];    
+    catch
+        h = 0;
+    end
 end
 
 function X = firstSDPVAR(List)
-X = [];
-for i = 1:length(List)
-    if isa(List{i},'sdpvar')
-        X = List{i};
-        break
+    X = [];
+    for i = 1:length(List)
+        if isa(List{i},'sdpvar')
+            X = List{i};
+            break
+        end
     end
+end
+
+function result = gemInPath(varargin)
+    persistent gemFound
+    
+    if nargin >= 1
+        switch varargin{1}
+            case 'clear'
+                gemFound = [];
+            otherwise
+                disp(['Invalid command for gemInPath in YALMIP.m']);
+        end
+        return;
+    end
+    
+    if isempty(gemFound)
+        gemFound = (exist('gem', 'class') == 8);
+    end
+    result = gemFound;
 end


### PR DESCRIPTION
Since I cannot modify denisrosset:gem-avoid-caught-error, here is the updated version of https://github.com/yalmip/YALMIP/pull/1049.

Following the discussion in #1049 and #985, the proposed solution consists in using a persistent variable in a dedicated subfunction to check for the existence of the gem library only once. This way, we obtain the robustness of an actual test of existence without sacrificing performance (the test is typically done only once per session), and no error is thrown, except if something is wrong. The persistent variable is also cleaned transparently when calling `yalmip('clear')`, allowing for a change in the path can be taken into consideration.

Below is the result of a performance test comparing the previous implementation (subject to throwing errors), with the new one.

Before/after with the gem library in the path
```
>> yalmip('clear');
>> tic;for i = 1:1e4;x=sdpvar(1);end;toc
Elapsed time is 2.011326 seconds.
>> yalmip('clear');
>> tic;for i = 1:1e4;x=sdpvar(1);end;toc
Elapsed time is 2.288607 seconds.
```

Before/after without gem in the path
```
>> yalmip('clear');
>> tic;for i = 1:1e4;x=sdpvar(1);end;toc
Elapsed time is 1.988402 seconds.
>> yalmip('clear');
>> tic;for i = 1:1e4;x=sdpvar(1);end;toc
Elapsed time is 2.045295 seconds.
```