### PR TITLE
fixed monolist parameter dmin

### DIFF
--- a/extras/monolist.m
+++ b/extras/monolist.m
@@ -205,7 +205,7 @@ end
 new_x = reshape(new_x(:),length(new_x),1);
 if dmin > 0
     for i = 1:length(new_x)
-        if degree(new_x(i)) < dmin
+        if sum(powers(i,:)) < dmin
             keep(i) = 0;
         else
             keep(i) = 1;


### PR DESCRIPTION
I noticed that ``monolist`` returns an empty vector when dmin is set > 0 and it shouldn't. I modified the function to return the expected value.

 Ex.: Before this commit 
```
>> monolist([2;3;5],3,3)

ans =

  0×1 empty double column vector
```

After this commit

```
>> monolist([2;3;5],3,3)
ans =

     8
    12
    18
    27
    20
    30
    45
    50
    75
   125
```

I hope this is a good solution :)