### PR TITLE
Minor edits for compatibility with octave

### DIFF
--- a/modules/global/addSquaredLinearEqualityCuts.m
+++ b/modules/global/addSquaredLinearEqualityCuts.m
@@ -1,4 +1,4 @@
-function p = addMultipliedEqualityCuts(p)
+function p = addSquaredLinearEqualityCuts(p)
 
 newRows = [];
 for j = 1:p.K.f

--- a/modules/global/bmibnb_branch_and_bound.m
+++ b/modules/global/bmibnb_branch_and_bound.m
@@ -1,4 +1,4 @@
-function [x_min,solved_nodes,lower,upper,lower_hist,upper_hist,solution_hist,timing,counter,problem] = branch_and_bound(p,x_min,upper,timing,solution_hist)
+function [x_min,solved_nodes,lower,upper,lower_hist,upper_hist,solution_hist,timing,counter,problem] = bmibnb_branch_and_bound(p,x_min,upper,timing,solution_hist)
 
 % *************************************************************************
 % Initialize diagnostic code

--- a/modules/global/propagate_bounds_from_separable_quadratic_equality.m
+++ b/modules/global/propagate_bounds_from_separable_quadratic_equality.m
@@ -1,4 +1,4 @@
-function p = update_sumsepquad_bounds(p);
+function p = propagate_bounds_from_separable_quadratic_equality(p);
 % Looking for case z == b + q1(x1) + q2(x2) + ... where q quadratic
 
 % Temporarily treat polynomials/functions as linear variables

--- a/solvers/definesolvers.m
+++ b/solvers/definesolvers.m
@@ -605,6 +605,7 @@ solver(i).constraint.integer = 1;
 solver(i).constraint.binary = 1;
 i = i+1;
 
+if ~exist('OCTAVE_VERSION','builtin')
 solver(i) = lpsolver;
 solver(i).tag     = 'GLPK';
 solver(i).version = 'GLPKMEX';
@@ -613,6 +614,7 @@ solver(i).call    = 'callglpk';
 solver(i).constraint.integer = 1;
 solver(i).constraint.binary = 1;
 i = i+1;
+endif
 
 % Needed for Later Octave version (glpkmex is depracated)
 solver(i) = lpsolver;


### PR DESCRIPTION
Minor edits for compatibility with octave:
1. Fix function names in modules/global/addSquaredLinearEqualityCuts.m and modules/global/bmibnb_branch_and_bound.m and modules/global/propagate_bounds_from_separable_quadratic_equality.m
2. Don't look for glpkmex in definesolvers.m
