### PR TITLE
Added registerjacobian to avoid recomputing jacobians

### DIFF
--- a/@sdpvar/linearize.m
+++ b/@sdpvar/linearize.m
@@ -25,11 +25,8 @@ p0 = double(p);
 n = size(p,1);
 m = size(p,2);
 
-if ~isfield(p.extra, 'jacobian')
+if ~isfield(p.extra, 'jacobian') || isempty(p.extra.jacobian)
     p.extra.jacobian = jacobian(p,x);
-    % assignin('caller', inputname(1), p) 
-    % this would automatically register the jacobian for the caller but 
-    % this may be an unwanted behavior so I commented it out
 end
 J = value(p.extra.jacobian);
 

--- a/@sdpvar/linearize.m
+++ b/@sdpvar/linearize.m
@@ -25,12 +25,19 @@ p0 = double(p);
 n = size(p,1);
 m = size(p,2);
 
+if ~isfield(p.extra, 'jacobian')
+    p.extra.jacobian = jacobian(p,x);
+    % assignin('caller', inputname(1), p) 
+    % this would automatically register the jacobian for the caller but 
+    % this may be an unwanted behavior so I commented it out
+end
+J = value(p.extra.jacobian);
+
 if min(n,m)>1
     plin = [];
-    J = value(jacobian(p,x));
     for i = 1:m
         plin = [plin p0(:,i)+squeeze(J(:,i,:))*(x-x0)];
     end
 else
-    plin = p0+double(jacobian(p,x))*(x-x0);
+    plin = p0+double(J)*(x-x0);
 end

--- a/@sdpvar/registerjacobian.m
+++ b/@sdpvar/registerjacobian.m
@@ -1,0 +1,7 @@
+function [p] = registerjacobian(p)
+%REGISTERJACOBIAN Register jacobians to an expression
+
+if ~isfield(p.extra, 'jacobian')
+    x = recover(depends(p));
+    p.extra.jacobian = jacobian(p,x);
+end

--- a/extras/@lmi/registerjacobian.m
+++ b/extras/@lmi/registerjacobian.m
@@ -1,0 +1,13 @@
+function [F] = registerjacobian(F)
+%REGISTERJACOBIAN Register jacobians to all constraints
+
+F = flatten(F);
+Counter = length(F.LMIid);
+for i = 1:Counter
+    switch F.clauses{i}.type
+        case {1,2,3}
+            Fi = F.clauses{i}.data;
+            F.clauses{i}.data = registerjacobian(Fi);
+        otherwise
+    end
+end


### PR DESCRIPTION
Hello again!

In the same line as https://github.com/yalmip/YALMIP/pull/1179, I added these `registerjacobian` functions that compute a jacobian for a constraint or expression and save it to avoid recomputing in the future. 

More specifically, when linearizing a constraint with many variables several times, the `jacobian` call becomes the bottleneck so computing it once and using it afterward saves a lot of time.

I am not sure if the `extra` struct would be the best place to save it, so feel free to give your opinion about it.

Also, attention to [@sdpvar/linearize.m#L30](https://github.com/egidioln/YALMIP/blob/30bcfe8da431aed55f749224014dc18752c10e8a/@sdpvar/linearize.m#L30) where I was wondering whether this should be an automatic feature (i.e., jacobians are registered whenever linearized is called for an `sdpvar`).