### PR TITLE
add support for dualizing complex problems without mapping to reals

### DIFF
--- a/@sdpvar/is.m
+++ b/@sdpvar/is.m
@@ -112,8 +112,48 @@ switch property
                 return;
             end
         end
-                
+
     case 'shiftsdpcone'
+        
+        if isequal(X.conicinfo,[1 0])
+            YESNO = 1;
+            return
+        elseif isequal(X.conicinfo,[1 1])
+            YESNO = 1;
+            return
+        elseif  isequal(X.conicinfo,[sqrt(-1) 0])
+            YESNO = 1;
+            return
+        elseif isequal(X.conicinfo,[1 1])
+            YESNO = 1;
+            return
+        end
+        
+        % Fixes bug #15
+        if length(X.lmi_variables)>1
+            if ~all(diff(X.lmi_variables)==1)
+                YESNO=0;
+                return;
+            end
+        end
+        
+        base = X.basis;
+        n = X.dim(1);
+        base(:,1)=0;
+        YESNO = full(issymmetric(X) && nnz(base)==n*n && all(sum(base,2)==1)) && length(X.lmi_variables)==n*(n+1)/2 && isreal(X);
+        if YESNO
+            % Possible case
+            % FIX : Stupidly slow and complex
+            [i,j,k] = find(base');
+            Y = reshape(1:n^2,n,n);
+            Y = tril(Y);
+            Y = (Y+Y')-diag(sparse(diag(Y)));
+            [uu,oo,pp] = unique(Y(:));
+            YESNO = isequal(i,pp+1);            
+        end
+        
+                
+    case 'complexshiftsdpcone'
         
         if isequal(X.conicinfo,[1 0])
             YESNO = 1;

--- a/dev/tests/dualize/test_dualize_sdp.m
+++ b/dev/tests/dualize/test_dualize_sdp.m
@@ -270,3 +270,11 @@ testCase.assertTrue(sol1.problem == 0);
 testCase.assertTrue(sol2.problem == 0);
 testCase.assertTrue(abs(o1 - o2) <= 1e-4);
 
+function test13(testCase)
+yalmip('clear')
+N = 5;
+X = sdpvar(N,N,'hermitian','complex');
+F = [X>=0, X(1) == 2];
+opts = sdpsettings('dualize',1,'verbose',1);
+sol = optimize(F,trace(X),opts);
+testCase.assertTrue(sol.problem == 0);

--- a/extras/compileinterfacedata.m
+++ b/extras/compileinterfacedata.m
@@ -1,4 +1,4 @@
-function [interfacedata,recoverdata,solver,diagnostic,F,Fremoved,ForiginalQuadratics] = compileinterfacedata(F,aux_obsolete,logdetStruct,h,options,findallsolvers,parametric)
+function [interfacedata,recoverdata,solver,diagnostic,F,Fremoved,ForiginalQuadratics] = compileinterfacedata(F,aux_obsolete,logdetStruct,h,options,findallsolvers,parametric,solvers_from_solvesdp)
 
 persistent CACHED_SOLVERS
 persistent allsolvers
@@ -16,6 +16,10 @@ ForiginalQuadratics = [];
 %% Did we make the call from SOLVEMP
 if nargin<7
     parametric = 0;
+end
+
+if nargin < 8
+	solvers_from_solvesdp = [];
 end
 
 % *************************************************************************
@@ -154,7 +158,7 @@ end
 % Finding solvers can be very slow on some systems. To alleviate this
 % problem, YALMIP can cache the list of available solvers.
 % *************************************************************************
-if (options.cachesolvers==0) | isempty(CACHED_SOLVERS)
+if ((options.cachesolvers==0) | isempty(CACHED_SOLVERS)) & isempty(solvers_from_solvesdp)
     getsolvertime = clock;
     [solvers,kept,allsolvers] = getavailablesolvers(findallsolvers,options);
     getsolvertime = etime(clock,getsolvertime);
@@ -179,8 +183,11 @@ if (options.cachesolvers==0) | isempty(CACHED_SOLVERS)
         NCHECKS = 5;
     end
     CACHED_SOLVERS = solvers;
-else
+elseif isempty(solvers_from_solvesdp)
     solvers = CACHED_SOLVERS;
+else
+	solvers = solvers_from_solvesdp;
+	allsolvers = definesolvers;
 end
 
 % *************************************************************************

--- a/extras/dualize.m
+++ b/extras/dualize.m
@@ -725,9 +725,9 @@ for j = 1:1:n_cones
             sA(id) = 2*sA(id);
 
             [iFc,jFc,sFc] = find(Fic);
-            iAc = indc(iFc);
-            jAc = jFc;
-            sAc = sFc;
+            iAc = indc(iFc(:)); %ensure these are column vectors
+            jAc = jFc(:);
+            sAc = sFc(:);
             the_col = 1+floor((iAc-1)/ns(j));
             the_row = iAc-(the_col-1)*ns(j);
             these_must_be_transposed = find(the_row > the_col);
@@ -964,5 +964,6 @@ for i = 1:length(F)
         implicit_positive = [implicit_positive vars(ii)];
     end
 end
+
 
 

--- a/extras/solvesdp.m
+++ b/extras/solvesdp.m
@@ -241,6 +241,15 @@ else
     solvers = CACHED_SOLVERS;
 end
 
+%here we are not actually selecting a solver, just checking whether it supports complex numbers
+solverindex = min(find(strcmpi(lower({solvers.tag}),lower(options.solver))));
+if isempty(solverindex)
+	complexsolver = 0;
+else
+	solver = solvers(solverindex);
+	complexsolver = solver.complex; 
+end
+
 % Dualize the problem?
 if ~isempty(F)
     if options.dualize == -1
@@ -253,7 +262,7 @@ if ~isempty(F)
     end
 end
 if options.dualize == 1   
-    [Fd,objd,aux1,aux2,aux3,complexInfo] = dualize(F,h,[],[],[],options,solvers);
+    [Fd,objd,aux1,aux2,aux3,complexInfo] = dualize(F,h,[],[],[],options,complexsolver);
     options.dualize = 0;
     diagnostic = solvesdp(Fd,-objd,options);
     if ~isempty(complexInfo)

--- a/solvers/definesolvers.m
+++ b/solvers/definesolvers.m
@@ -773,7 +773,7 @@ solver(i).call    = 'callsedumi';
 solver(i).constraint.equalities.linear = 1;
 solver(i).constraint.inequalities.secondordercone.linear = 1;
 solver(i).constraint.inequalities.rotatedsecondordercone.linear = 0;
-solver(i).complex = 0;
+solver(i).complex = 1;
 i = i+1;
 
 solver(i) = sdpsolver;


### PR DESCRIPTION
If the solver is set with `solver.complex = 1` in `definesolvers.m` the `dualize.m` function no longer maps the problem to the reals, but leaves the problem on the complexes, that is then solved much faster.

Currently only SeDuMi supports this, but hopefully faster solvers will add this capability in the future.

I'm just worried about breaking current SeDuMi installations: they have a bug that make them give incorrect answers on complex problems. Can YALMIP detect the version of the solver? If so, then we could ask the SeDuMi guys to release a bugfix version 1.3.6, and mark only that one with `solver.complex = 1`, and so nobody's code is broken.