### PR TITLE
Fixes #1232

### DIFF
--- a/extras/adjoint.m
+++ b/extras/adjoint.m
@@ -12,7 +12,7 @@ end
 
 A = [];
 if n == 1
-    A = X;
+    A = 1;
     return
 end
 


### PR DESCRIPTION
This PR proposes a change to the adjoint function in adjoint.m. Specifically, the change will modify the behavior of adjoint(M) when M is a scalar. Currently, when M is a scalar, the function returns M itself. However, this PR proposes that adjoint(M) should instead return 1 for scalar M.

