### PR TITLE
Fixes #1170 and #1171

### DIFF
--- a/extras/@constraint/constraint.m
+++ b/extras/@constraint/constraint.m
@@ -41,7 +41,7 @@ if isa(Z,'double')
         Z = Z(:);
         switch quantifier
             case '=='
-                if all(Z)==0
+                if all(Z==0)
                     warning('Equality constraint evaluated to trivial true.')
                     F = [];
                     return

--- a/extras/dualize.m
+++ b/extras/dualize.m
@@ -956,6 +956,7 @@ for i = 1:length(F)
     n = sqrt(size(B,1));
     d = 1:(n+1):n^2;
     B = B(d,:);
+    B = real(B); % Temporary fix to remove negligible imaginary parts that can occur for large problems
     candidates = find((B(:,1) == 0) & (sum(B | B,2) == 1) & (sum(B,2) == 1));
     if ~isempty(candidates)
         vars = getvariables(Fi);


### PR DESCRIPTION
This PR fixes issues #1170 and #1171 
- #1170 is a typo that incorrectly checks whether equality constraints are satisfied
- #1171 is only affects very large problems where numerically we sometimes get left with a very small (~10^-17) imaginary part of a matrix that the code assumes (and in principle should be) real, which crashes dualization of a problem.