### PR TITLE
Add COPT support for YALMIP

### DIFF
--- a/extras/export.m
+++ b/extras/export.m
@@ -151,6 +151,8 @@ end
 % CONVERT
 % ******************************************
 switch lower(solver.tag)
+    case 'copt'
+        model = yalmip2copt(interfacedata);
 
     case 'cplex'
 

--- a/extras/pruneOptions.m
+++ b/extras/pruneOptions.m
@@ -1,5 +1,15 @@
 function options = pruneOptions(options)
 
+if isempty(options.copt)
+    return
+elseif isequal(options.copt,options.default.copt)
+    options.copt = [];
+else
+    [same,opsDiff] = isequalInf(options.copt,options.default.copt);
+    if ~same
+        options.copt = opsDiff;
+    end
+end
 % Mosek is easy to check since there are no inf parameters...
 if isempty(options.mosek)
     return

--- a/extras/sdpsettings.m
+++ b/extras/sdpsettings.m
@@ -146,6 +146,9 @@ else
     options.clp = setup_clp_options;
     Names = appendOptionNames(Names,options.clp,'clp');
 
+    options.copt = setup_copt_options;
+    Names = appendOptionNames(Names,options.copt,'copt');
+
     options.cplex = setup_cplex_options;
     Names = appendOptionNames(Names,options.cplex,'cplex');
 
@@ -280,7 +283,8 @@ else
 
     options.xpress = setup_xpress_options;
     Names = appendOptionNames(Names,options.xpress,'xpress');
-      
+    
+    options.default.copt = options.copt;
     options.default.cplex = options.cplex;
     options.default.gurobi = options.gurobi;
     options.default.mosek = options.mosek;   
@@ -652,6 +656,49 @@ catch
     clp.primalpivot = 1;
     clp.dualpivot = 1;
 end
+
+function copt = setup_copt_options
+copt.TimeLimit         = 1e20;
+copt.MatrixTol         = 1e-10;
+copt.FeasTol           = 1e-6;
+copt.DualTol           = 1e-6;
+copt.IntTol            = 1e-6;
+copt.RelGap            = 1e-4;
+copt.Logging           = 1;
+copt.LogToConsole      = 1;
+copt.Presolve          = -1;
+copt.Scaling           = -1;
+copt.Dualize           = -1;
+copt.LpMethod          = -1;
+copt.ReqFarkasRay      = 0;
+copt.DualPrice         = -1;
+copt.DualPerturb       = -1;
+copt.CutLevel          = -1;
+copt.RootCutLevel      = -1;
+copt.TreeCutLevel      = -1;
+copt.RootCutRounds     = -1;
+copt.NodeCutRounds     = -1;
+copt.HeurLevel         = -1;
+copt.RoundingHeurLevel = -1;
+copt.DivingHeurLevel   = -1;
+copt.SubMipHeurLevel   = -1;
+copt.StrongBranching   = -1;
+copt.ConflictAnalysis  = -1;
+copt.NodeLimit         = -1;
+copt.MipTasks          = -1;
+copt.BarHomogeneous    = -1;
+copt.BarOrder          = -1;
+copt.BarIterLimit      = 500;
+copt.Threads           = -1;
+copt.BarThreads        = -1;
+copt.SimplexThreads    = -1;
+copt.CrossoverThreads  = -1;
+copt.Crossover         = 1;
+copt.SDPMethod         = -1;
+copt.IISMethod         = -1;
+copt.FeasRelaxMode     = 0;
+copt.MipStartMode      = -1;
+copt.MipStartNodeLimit = -1;
 
 function cplex = setup_cplex_options
 try

--- a/modules/global/adjustMaxTime.m
+++ b/modules/global/adjustMaxTime.m
@@ -5,6 +5,7 @@ remaining = maxtime-elapsed;
 budgetForSolver = max(1,ceil(remaining));
 
 % TODO: Support more solvers
+p.options.copt.TimeLimit = budgetForSolver;
 p.options.cplex.timelimit = budgetForSolver;
 p.options.mosek.MSK_DPAR_MIO_MAX_TIME = budgetForSolver;
 p.options.gurobi.TimeLimit = budgetForSolver;

--- a/solvers/callcopt.m
+++ b/solvers/callcopt.m
@@ -1,0 +1,115 @@
+function output = callcopt(interfacedata)
+
+options = interfacedata.options;
+problem = yalmip2copt(interfacedata);
+
+if interfacedata.options.savedebug
+    save coptdebug problem
+end
+
+if options.showprogress; showprogress('Call COPT', options.showprogress); end
+solvertime = tic;
+solution   = copt_solve(problem, problem.params);
+solvertime = toc(solvertime);
+
+if isfield(solution, 'rowmap')
+    nrow = length(solution.rowmap);
+    x = zeros(nrow, 1);
+    if isfield(solution, 'psdpi')
+        for i = 1:nrow
+            if solution.rowmap(i) < 0
+                x(i) = -solution.psdpi(-solution.rowmap(i));
+            else
+                x(i) = -solution.pi(solution.rowmap(i));
+            end
+        end
+    end
+
+    if isfield(solution, 'psdx')
+        if isfield(solution, 'x')
+            y = [solution.x; solution.psdx];
+        else
+            y = solution.psdx;
+        end
+
+        dims = problem.conedata.K;
+
+        D_struc = y(1:dims.f + dims.l + sum(dims.q) + sum(dims.r));
+        if isfield(solution, 'psdx')
+            top = 1 + dims.f + dims.l + sum(dims.q) + sum(dims.r);
+            for i = 1:length(dims.s)
+                n = dims.s(i);
+                sdpdual = y(top:top + n * (n + 1) / 2 - 1);
+                Z = zeros(n);
+                ind = find(tril(ones(n)));
+                Z(ind) = sdpdual;
+                Z = Z + Z';
+                ind = find(speye(n));
+                Z(ind) = Z(ind) / 2.0;
+                D_struc = [D_struc; Z(:)];
+                top = top + n * (n + 1) / 2;
+            end
+        end
+    else
+        D_struc = [];
+    end
+
+    dualstatus = solution.status;
+    switch dualstatus
+        case 'infeasible'
+            solution.status = 'unbounded';
+        case 'unbounded'
+            solution.status = 'infeasible';
+        otherwise
+            solution.status = dualstatus;
+    end
+else
+    numvars = length(interfacedata.c);
+
+    if isfield(solution, 'x')
+        x = solution.x(1:numvars);
+    else
+        x = zeros(numvars, 1);
+    end
+
+    if isfield(solution, 'pi')
+        D_struc = -solution.pi;
+    else
+        D_struc = [];
+    end
+end
+
+switch solution.status
+    case 'optimal'
+        status = 0;
+    case 'infeasible'
+        status = 1;
+    case 'unbounded'
+        status = 2;
+    case {'timeout', 'nodelimit'}
+        status = 3;
+    case 'numerical'
+        status = 4;
+    case 'interrupted'
+        status = 16;
+    case 'unstarted'
+        status = -4;
+    otherwise
+        status = -1;
+end
+
+if interfacedata.options.savesolverinput
+    solverinput.model = problem;
+else
+    solverinput = [];
+end
+
+if interfacedata.options.savesolveroutput
+    solveroutput.result = solution;
+else
+    solveroutput = [];
+end
+
+infostr = yalmiperror(status, interfacedata.solver.tag);
+
+output  = createOutputStructure(x, D_struc, [], status, infostr, solverinput, solveroutput, solvertime);

--- a/solvers/definesolvers.m
+++ b/solvers/definesolvers.m
@@ -111,6 +111,34 @@ i = 1;
 % DEFINE SOLVERS
 % ****************************
 
+solver(i) = lpsolver;
+solver(i).tag = 'COPT';
+solver(i).version = 'COPTMEX';
+solver(i).checkfor = {'copt_solve'};
+solver(i).call = 'callcopt';
+solver(i).objective.quadratic.convex = 0;
+solver(i).constraint.inequalities.elementwise.quadratic.convex = 0;
+solver(i).constraint.inequalities.secondordercone.linear = 1;
+solver(i).constraint.integer = 1;
+solver(i).constraint.binary = 1;
+solver(i).constraint.semivar = 0;
+solver(i).constraint.semiintvar = 0;
+solver(i).constraint.sos1 = 1;
+solver(i).constraint.sos2 = 1;
+solver(i).supportsinitial = 1;
+solver(i).supportsinitialNAN = 1;
+i = i + 1;
+
+solver(i) = sdpsolver;
+solver(i).tag = 'COPT';
+solver(i).version = 'COPTMEX';
+solver(i).checkfor = {'copt_solve'};
+solver(i).call = 'callcopt';
+solver(i).constraint.equalities.linear = 1;
+solver(i).constraint.inequalities.secondordercone.linear = 1;
+solver(i).constraint.inequalities.rotatedsecondordercone.linear = 1;
+i = i + 1;
+
 solver(i) = qpsolver;
 solver(i).tag     = 'GUROBI';
 solver(i).version = '';

--- a/solvers/yalmip2copt.m
+++ b/solvers/yalmip2copt.m
@@ -1,0 +1,172 @@
+function model = yalmip2copt(interfacedata)
+
+F_struc            = interfacedata.F_struc;
+K                  = interfacedata.K;
+c                  = interfacedata.c;
+lb                 = interfacedata.lb;
+ub                 = interfacedata.ub;
+x0                 = interfacedata.x0;
+integer_variables  = interfacedata.integer_variables;
+binary_variables   = interfacedata.binary_variables;
+semicont_variables = interfacedata.semicont_variables;
+n                  = length(c);
+
+if ~isempty(K.s) && any(K.s)
+    if ~isempty(integer_variables) || ~isempty(binary_variables) || ~isempty(semicont_variables)
+        warning('WARNING: Unsupported problem types for COPT');
+    end
+
+    if ~isempty(ub)
+        [F_struc, K] = addStructureBounds(F_struc, K, ub, lb);
+    end
+
+    data.A = -F_struc(:, 2:end);
+    data.b = full(F_struc(:, 1));
+    data.c = full(c);
+
+    dims = [];
+    dims.f = K.f;
+    dims.l = K.l;
+    dims.q = K.q;
+    dims.r = K.r;
+    dims.s = K.s;
+
+    sdpA = data.A(1 + K.f + K.l + sum(K.q) + sum(K.r):end, :);
+    sdpb = data.b(1 + K.f + K.l + sum(K.q) + sum(K.r):end, :);
+    data.A = data.A(1:K.f + K.l + sum(K.q) + sum(K.r), :);
+    data.b = data.b(1:K.f + K.l + sum(K.q) + sum(K.r), :);
+
+    top = 1;
+    for i = 1:length(K.s)
+        A = sdpA(top:top + K.s(i)^2 - 1, :);
+        b = sdpb(top:top + K.s(i)^2 - 1, :);
+        n = K.s(i);
+        ind = find(tril(ones(n)));
+        A = A(ind, :);
+        b = b(ind);
+        data.A = [data.A; A];
+        data.b = [data.b; b];
+        top = top + K.s(i)^2;
+    end
+
+    conedata.A = data.A';
+    conedata.c = -data.b;
+    conedata.b = -data.c;
+    conedata.K = dims;
+    conedata.objsen = 'max';
+    model.conedata = conedata;
+
+    interfacedata.options = pruneOptions(interfacedata.options);
+
+    model.params = interfacedata.options.copt;
+    if interfacedata.options.verbose == 0
+        model.params.Logging = 0;
+    else
+        model.params.Logging = 1;
+    end
+
+    return
+end
+
+if ~isempty(ub)
+    LB = lb;
+    UB = ub;
+    if ~isempty(binary_variables)
+        LB(binary_variables) = round(LB(binary_variables));
+        UB(binary_variables) = round(UB(binary_variables));
+    end
+    if ~isempty(integer_variables)
+        LB(integer_variables) = round(LB(integer_variables));
+        UB(integer_variables) = round(UB(integer_variables));
+    end
+else
+    LB = -inf(n, 1);
+    UB = +inf(n, 1);
+end
+
+if ~isempty(semicont_variables)
+    warning('WARNING: Semi-continuous or semi-integer variables are not supported.');
+end
+
+if size(F_struc, 1) > 0
+    A   = -F_struc(:, 2:end);
+    RHS = full(F_struc(:, 1));
+    LHS = -inf(length(RHS), 1);
+else
+    A   = sparse(ones(1, length(c)));
+    RHS = +inf(length(c), 1);
+    LHS = -inf(length(c), 1);
+end
+
+if K.f > 0
+    LHS(1:K.f) = RHS(1:K.f);
+end
+
+VARTYPE = char(ones(length(c), 1) * 67);
+if isempty(semicont_variables)
+    VARTYPE(integer_variables) = 'I';
+    VARTYPE(binary_variables)  = 'B';
+else
+    VARTYPE(setdiff(integer_variables, semicont_variables)) = 'I';
+    VARTYPE(binary_variables) = 'B';
+    VARTYPE(setdiff(semicont_variables, integer_variables)) = 'C';
+    VARTYPE(intersect(semicont_variables, integer_variables)) = 'I';
+end
+
+% model.objsen = 'min';
+model.objcon = full(interfacedata.f);
+if isempty(A)
+    model.A = spalloc(0, length(c), 0);
+else
+    model.A = sparse(A);
+end
+model.obj   = full(c);
+model.lb    = LB;
+model.ub    = UB;
+model.vtype = VARTYPE;
+model.lhs   = LHS;
+model.rhs   = RHS;
+
+if K.q(1) > 0
+    nconevar = sum(K.q);
+    top = size(F_struc, 2) - 1;
+
+    model.A     = [model.A, [spalloc(K.f + K.l, nconevar, 0); speye(nconevar)]];
+    model.obj   = [model.obj; zeros(nconevar, 1)];
+    model.lb    = [model.lb; -inf(nconevar, 1)];
+    model.ub    = [model.ub; +inf(nconevar, 1)];
+    model.vtype = [model.vtype; char(ones(nconevar, 1) * 67)];
+
+    model.lhs(1 + K.f + K.l:end) = model.rhs(1 + K.f + K.l:end);
+
+    for i = 1:length(K.q)
+        model.cone(i).type = 1;
+        model.cone(i).vars = top + 1:top + K.q(i);
+        top = top + K.q(i);
+    end
+end
+
+if ~isempty(K.sos.type)
+    for i = 1:length(K.sos.type)
+        if isa(K.sos.type(i), 'char')
+            model.sos(i).type = str2num(K.sos.type(i));
+        else
+            model.sos(i).type = K.sos.type(i);
+        end
+        model.sos(i).vars    = full(K.sos.variables{i}(:)');
+        model.sos(i).weights = full(K.sos.weight{i}(:)'); 
+    end
+end
+
+interfacedata.options = pruneOptions(interfacedata.options);
+
+model.params = interfacedata.options.copt;
+if interfacedata.options.verbose == 0
+    model.params.Logging = 0;
+else
+    model.params.Logging = 1;
+end
+
+if ~isempty(x0)
+    model.start = x0;
+end


### PR DESCRIPTION
This PR adds COPT support for YALMIP, you can download the MEX binaries of COPT-MATLAB from https://github.com/leavesgrp/COPT-MATLAB/releases and follow the userguide for setup instructions.

If you want to solve larger instances via COPT, a license is required and you can obtain one from https://www.shanshu.ai/copt.

If you have any questions, feel free to contact me. 

Thanks!