### PR TITLE
PIQP solver interface

### DIFF
--- a/extras/export.m
+++ b/extras/export.m
@@ -167,6 +167,9 @@ switch lower(solver.tag)
     case 'osqp'
         model = yalmip2osqp(interfacedata);
 
+    case 'piqp'
+        model = yalmip2piqp(interfacedata);
+
     case 'cbc'
         model = yalmip2cbc(interfacedata);
 

--- a/extras/sdpsettings.m
+++ b/extras/sdpsettings.m
@@ -233,6 +233,9 @@ else
     options.pensdp = setup_pensdp_options;
     Names = appendOptionNames(Names,options.pensdp,'pensdp');
 
+    options.piqp = setup_piqp_options;
+    Names = appendOptionNames(Names,options.piqp,'piqp');
+
     options.pop = setup_pop_options;
     Names = appendOptionNames(Names,options.pop,'pop');
 
@@ -290,7 +293,7 @@ else
     options.default.copt = options.copt;
     options.default.cplex = options.cplex;
     options.default.gurobi = options.gurobi;
-    options.default.mosek = options.mosek;   
+    options.default.mosek = options.mosek;
     options.default.osqp = options.osqp;   
     options.default.xpress = options.xpress;   
 end
@@ -1048,6 +1051,14 @@ pensdp.P_EPS = 1e-6;
 pensdp.UMIN = 1e-14;
 pensdp.ALPHA = 1e-2;
 pensdp.P0 = 0.9;
+
+function piqp_options = setup_piqp_options
+try
+    s = piqp('dense');
+    piqp_options = s.get_settings();
+catch
+    piqp_options =[];
+end
 
 function sparsecolo = setup_sparsecolo_options
 sparsecolo.SDPsolver = '';

--- a/solvers/callpiqp.m
+++ b/solvers/callpiqp.m
@@ -1,0 +1,69 @@
+function output = callpiqp(interfacedata)
+
+options = interfacedata.options;
+model = yalmip2piqp(interfacedata);
+
+if options.savedebug
+    save debugfile model
+end
+
+if options.showprogress;showprogress(['Calling ' interfacedata.solver.tag],options.showprogress);end
+
+% Define verbose option
+options.piqp.verbose = options.verbose;
+
+% Determine whether problem is sparse
+is_sparse = issparse(model.P) || issparse(model.A) || issparse(model.G);
+
+% Solve with PIQP
+if is_sparse
+    PIQPSolver = piqp('sparse');
+else
+    PIQPSolver = piqp('dense');
+end
+PIQPSolver.setup(model.P, model.c, ...
+                 model.A, model.b, ...
+                 model.G, model.h, ...
+                 model.x_lb, model.x_ub, ...
+                 options.piqp);
+results = PIQPSolver.solve();
+
+switch results.info.status_val
+    case 1
+        problem = 0;
+    case -1
+        problem = 3;
+    case -2
+        problem = 1;
+    case -3
+        problem = 1;
+    case -8
+        problem = 4;
+    case -9
+        problem = 7;
+    case -10
+        problem = 7;
+    otherwise
+        problem = -1;
+end
+
+% Solver time
+solvertime = results.info.run_time;
+
+% Standard interface
+Primal      = results.x(:);
+Dual        = [results.y; results.z];
+infostr     = yalmiperror(problem,interfacedata.solver.tag);
+if ~options.savesolverinput
+    solverinput = [];
+else
+    solverinput = model;
+end
+if ~options.savesolveroutput
+    solveroutput = [];
+else
+    solveroutput = results;
+end
+
+% Standard interface
+output = createOutputStructure(Primal,Dual,[],problem,infostr,solverinput,solveroutput,solvertime);

--- a/solvers/definesolvers.m
+++ b/solvers/definesolvers.m
@@ -711,6 +711,13 @@ solver(i).constraint.binary = 1;
 i = i+1;
 
 solver(i) = qpsolver;
+solver(i).tag     = 'PIQP';
+solver(i).version = '';
+solver(i).checkfor= {'piqp'};
+solver(i).call    = 'callpiqp';
+i = i+1;
+
+solver(i) = qpsolver;
 solver(i).tag     = 'qpOASES';
 solver(i).version = '';
 solver(i).checkfor= {'qpOASES'};

--- a/solvers/yalmip2piqp.m
+++ b/solvers/yalmip2piqp.m
@@ -1,0 +1,13 @@
+function model = yalmip2piqp(interfacedata);
+
+quadprog_model = yalmip2quadprog(interfacedata);
+
+model.options = interfacedata.options.piqp;
+model.P = quadprog_model.Q;
+model.c = quadprog_model.c;
+model.A = quadprog_model.Aeq;
+model.b = quadprog_model.beq;
+model.G = quadprog_model.A;
+model.h = quadprog_model.b;
+model.x_lb = quadprog_model.lb;
+model.x_ub = quadprog_model.ub;


### PR DESCRIPTION
This pull request adds support for the [PIQP](https://github.com/PREDICT-EPFL/piqp) solver (see [docs](https://predict-epfl.github.io/piqp) for installation instructions). The `yalmiptest` script seems to run fine with tests passing.

Let me know if any other changes are required.