### PR TITLE
Update kullbackleibler.m

### DIFF
--- a/operators/kullbackleibler.m
+++ b/operators/kullbackleibler.m
@@ -20,7 +20,7 @@ switch class(varargin{1})
             x = varargin{1}(:);
             y = varargin{2}(:);
         end
-        l = log(x./y);
+        l = -log(y./x);
         l(x<=0) = 0;
         l = real(l);
         varargout{1} = sum(x.*l);       


### PR DESCRIPTION
`kullbackleibler( *double*, *sdpvar*)` does not propagate convexity properly when 1st argument is a double.

 Simple example:

`x = 1; y = sdpvar; optimize([y >= 0.2, y<= 0.5], kullbackleibler(x, y), sdpsettings('solver', 'mosek'))`

Fix is straightforward: change in implementation `log(*double* ./ *sdpvar*)` to `-log(*sdpvar* ./ *double*)` which propages convexity properly.