### PR TITLE
Fix error in the error message

### DIFF
--- a/@sdpvar/subsref.m
+++ b/@sdpvar/subsref.m
@@ -149,7 +149,7 @@ try
                     end
                     return                
                 otherwise
-                    error(['Indexation  ''' Y.type Y.subs ''' not supported']) ;
+                    error(['Indexation  ''' Y.type ''' not supported']) ;
             end
         otherwise
             error(['Indexation with ''' Y.type ''' not supported']) ;


### PR DESCRIPTION
Not really relevant, but if you make a typo like `a = sdpvar; a.typo(1);` this causes the error message to error instead of giving something helpful.

![8fwsc5](https://github.com/yalmip/YALMIP/assets/997998/1dc5960f-6757-4508-a6b7-5d46799bae3a)