### PR TITLE
DAQP and OSQP savesolverinput fix

### DIFF
--- a/solvers/calldaqp.m
+++ b/solvers/calldaqp.m
@@ -26,6 +26,14 @@ sense =  [zeros(length(ub),1,'int32');5*ones(meq,1,'int32');zeros(m,1,'int32')];
 sense(find(isinf(lb)&isinf(ub))) = int32(4); % "ignore" if lb and ub are inf
 sense(bin_vars) = int32(16);
 
+% create a structure with the problem data
+model.H = H;
+model.f = f;
+model.A = A;
+model.bupper = bupper;
+model.blower = blower;
+model.sense = sense;
+
 if options.savedebug
     save debugfile model
 end

--- a/solvers/calldaqp.m
+++ b/solvers/calldaqp.m
@@ -27,12 +27,7 @@ sense(find(isinf(lb)&isinf(ub))) = int32(4); % "ignore" if lb and ub are inf
 sense(bin_vars) = int32(16);
 
 % create a structure with the problem data
-model.H = H;
-model.f = f;
-model.A = A;
-model.bupper = bupper;
-model.blower = blower;
-model.sense = sense;
+model = struct('H',H,'f',f,'A',A,'bupper',bupper,'blower',blower,'sense',sense);
 
 if options.savedebug
     save debugfile model

--- a/solvers/callosqp.m
+++ b/solvers/callosqp.m
@@ -59,7 +59,7 @@ infostr     = yalmiperror(problem,interfacedata.solver.tag);
 if ~options.savesolverinput
     solverinput = [];
 else
-    solverinput = model;
+    solverinput = struct('P',P,'q',q,'A',A,'l',l,'u',u);
 end
 if ~options.savesolveroutput
     solveroutput = [];


### PR DESCRIPTION
Using `savesolverinput` in combination with `DAQP` as the solver leads to an error - a structure with problem data was missing.
When using `OSQP`, the structure for `quadprog` was used instead.