### PR TITLE
Remove extraneous x0 param (warm start) in linprog calls

### DIFF
--- a/solvers/calllinprog.m
+++ b/solvers/calllinprog.m
@@ -5,10 +5,8 @@ options = interfacedata.options;
 F_struc = interfacedata.F_struc;
 c       = interfacedata.c;
 K       = interfacedata.K;
-Q       = interfacedata.Q;
 lb      = interfacedata.lb;
 ub      = interfacedata.ub;
-x0      = interfacedata.x0;
 
 showprogress('Calling LINPROG',options.showprogress);
 
@@ -43,17 +41,13 @@ if isfield(options.linprog,'LargeScale')
     end
 end
 
-if ~options.warmstart
-    x0 = [];
-end
-
 if options.savedebug
     ops = options.linprog;
-    save linprogdebug c A b Aeq beq lb ub ops x0
+    save linprogdebug c A b Aeq beq lb ub ops
 end
 
 solvertime = tic;
-[x,fmin,flag,output,lambda] = linprog(c, A, b, Aeq, beq, lb, ub, x0,options.linprog);
+[x,fmin,flag,output,lambda] = linprog(c, A, b, Aeq, beq, lb, ub, options.linprog);
 solvertime = toc(solvertime);
 problem = 0;
 

--- a/solvers/callquadprog.m
+++ b/solvers/callquadprog.m
@@ -53,10 +53,10 @@ if nnz(model.Q) == 0
     % cases. To avoid seeing this when we don't want the lambdas anyway, we
     % don't ask for it
     if options.saveduals
-        [x,fmin,flag,output,lambda] = linprog(model.c, model.A, model.b, model.Aeq, model.beq, model.lb, model.ub, model.x0,model.ops);
+        [x,fmin,flag,output,lambda] = linprog(model.c, model.A, model.b, model.Aeq, model.beq, model.lb, model.ub, model.ops);
     else
         lambda = [];
-        [x,fmin,flag,output] = linprog(model.c, model.A, model.b, model.Aeq, model.beq, model.lb, model.ub, model.x0,model.ops);
+        [x,fmin,flag,output] = linprog(model.c, model.A, model.b, model.Aeq, model.beq, model.lb, model.ub, model.ops);
     end
 else
     if options.saveduals


### PR DESCRIPTION
This should fix https://github.com/yalmip/YALMIP/issues/1381.

To be fair, I don't have a Matlab R2023+ version at hand, but at least I've tested on R2022a that solving LPs still works after this change....

Both [solvers/calllinprog.m](https://github.com/yalmip/YALMIP/blob/develop/solvers/calllinprog.m) and     [solvers/callquadprog.m](https://github.com/yalmip/YALMIP/blob/develop/solvers/callquadprog.m) are modified in this PR since the latter contains a shortcut to `linprog` in the case quadratic matrix Q is 0.