### PR TITLE
Solve SCS error when BLAS/LAPACK not installed

### DIFF
--- a/solvers/callscs.m
+++ b/solvers/callscs.m
@@ -58,7 +58,7 @@ if ~isempty(model.evalMap)
 else
     % Map to full format from tril
     Dual = y_s(1:scsmodel.cones.z+scsmodel.cones.l+sum(scsmodel.cones.q));
-    if ~isempty(scsmodel.cones.s) && any(scsmodel.cones.s)        
+    if isfield(scsmodel.cones, 's') && ~isempty(scsmodel.cones.s) && any(scsmodel.cones.s)        
         top = 1 + scsmodel.cones.z + scsmodel.cones.l + sum(scsmodel.cones.q);
         for i = 1:length(scsmodel.cones.s)
             n = scsmodel.cones.s(i);

--- a/solvers/yalmip2scs.m
+++ b/solvers/yalmip2scs.m
@@ -40,6 +40,11 @@ if ~isempty(cones.s) && any(cones.s)
     data.b = [data.b;expb];
 end
 
+% Remove cones.s if ==0 to avoid SCS fatal error if BLAS/LAPACK is not installed
+if isfield(cones, 's') && cones.s == 0
+    cones = rmfield(cones, 's');
+end
+
 %% Collect in one structure
 model.data = data;
 model.cones = cones;


### PR DESCRIPTION
The latest version of the SCS solver (version 3.2.3) does not work if the optional BLAS/LAPACK libraries are not installed (or not properly linked). The libraries are optional, since they are only used for Anderson acceleration and for semidefinite cone projection. However, when using YALMIP the SCS solver throughs a fatal error even when the optimization problem does not require these libraries.

The issue seems to be that YALMIP always creates a field `cones.s` even when no semidefinite cones are included in the optimization problem. This results in the following "FATAL error" message from SCS:
```
FATAL: syev failure, info = -5
ERROR: init_cone failure
Failure:could not initialize work
```
Looking into the problem, my guess is that SCS detects the existence of the  `cones.s` and tries to link to the BLAS/LAPACK libraries, even if `cones.s == 0`. 

As a minimal example, the following code produces the error and error message (tested on Windows 11 and macOS Ventura on Matlab R2023b using SCS version 3.2.3 and the latest YALMIP release):
```
yalmip('clear');
x = sdpvar(2, 1);
cost = 2*x(1)^2 + x(2)^2;
constraints = x(1) + x(2) == 1;
options = sdpsettings('solver' , 'scs');
sol = optimize(constraints, cost, options);
```

A simple solution is to remove the `cones.s` field if its value is `0`, which is what I've done in the commit of this pull request.

I'm creating the pull request to let you know about this issue and provide you with the solution I've adopted (to merge it if you see fit), but I don't know if my solutions creates any problems in other scenarios or parts of the code-base.