### PR TITLE
Adds support for sqrtm in gurobinonlinear.

### DIFF
--- a/solvers/yalmip2gurobinonlinear.m
+++ b/solvers/yalmip2gurobinonlinear.m
@@ -335,6 +335,9 @@ if length(interfacedata.evalMap) > 0
     if any(cellfun(@(x) strcmp(x.fcn, 'power_internal1'), interfacedata.evalMap))
         model.genconexpa = [];
     end
+    if any(cellfun(@(x) strcmp(x.fcn, 'sqrtm_internal'), interfacedata.evalMap))
+        model.genconpow = [];
+    end
         
     for i = 1:length(interfacedata.evalMap)
         f = interfacedata.evalMap{i};
@@ -355,6 +358,9 @@ if length(interfacedata.evalMap) > 0
                 % a^x
                 aux = struct('xvar',f.variableIndex,'yvar', f.computes,'a',interfacedata.evalMap{i}.arg{2});
                 model.genconexpa = [model.genconexpa aux];                
+            case 'sqrtm_internal'
+                aux = struct('xvar',f.variableIndex,'yvar', f.computes,'a',0.5);
+                model.genconpow = [model.genconpow aux];                
             otherwise
                 error(['GUROBI does not support "'  f.fcn '"']);
         end


### PR DESCRIPTION
Gurobi's genconpow needs support more generally, but at present it seems harder for me to implement, as YALMIP thinks Gurobi can't handle signomials in constraints or objectives, so it never gets as far as yalmip2gurobinonlinear.