### PR TITLE
@optimizer/subsref.m Update

### DIFF
--- a/extras/@optimizer/subsref.m
+++ b/extras/@optimizer/subsref.m
@@ -196,7 +196,12 @@ elseif isequal(subs.type,'{}')
                         temp = temp(:);
                         suppliedData(j) = 0;
                     else
-                        temp = data(:,left(j):self.diminOrig{j}(2)+left(j)-1,:);
+                        if size(data, 3) > 1
+                            temp = data(:,left(j):self.diminOrig{j}(2)+left(j)-1,:);
+                        else
+                            temp = data(:,left(j):self.diminOrig{j}(2)+left(j)-1);
+                        end
+
                         suppliedData(j) = 1;
                     end
                     temp = temp(:);


### PR DESCRIPTION
Implemented if/else block to prevent slicing of data if size(data, 3)==1.  This permits the passing of sparse arrays correctly into an optimizer object, which would throw an error otherwise, since N-dimensional slicing of sparse matrices is not permitted by MATLAB.