### PR TITLE
Fix `allvariables`, `getvariables`, `depends`, and `replace` when the constraints include complements.

### DIFF
--- a/extras/@lmi/depends.m
+++ b/extras/@lmi/depends.m
@@ -43,6 +43,9 @@ else
             for j = 1:length(clauses{i}.data)
                 Fivar = [Fivar getvariables(clauses{i}.data{j})];
             end
+        elseif clauses{i}.type == 55
+            % Complementarity Constraints, where we have a binvar in indicators
+            Fivar = [getvariables(clauses{i}.data) getvariables(clauses{i}.extra.indicators(:)')];
         else
             Fivar = getvariables(clauses{i}.data);
         end

--- a/extras/@lmi/getvariables.m
+++ b/extras/@lmi/getvariables.m
@@ -44,6 +44,9 @@ else
                 for j = 1:length(F.clauses{i}.data)
                     Fivars = [Fivars getvariables(F.clauses{i}.data{j})];
                 end
+            elseif F.clauses{i}.type == 55
+                % Complementarity Constraints, where we have a binvar in indicators
+                Fivars = [getvariables(F.clauses{i}.data) getvariables(F.clauses{i}.extra.indicators(:)')];
             else
                 Fivars = getvariables(F.clauses{i}.data);
             end

--- a/extras/@lmi/replace.m
+++ b/extras/@lmi/replace.m
@@ -22,6 +22,13 @@ keep = [];
 F = flatten(F);
 for i = 1:length(F.LMIid)
     F.clauses{i}.data = replace(F.clauses{i}.data,X,W,expand);
+    if F.clauses{i}.type == 55
+        % Complementarity Constraints, where we have a binvar in indicators
+        if ~is(W, 'binary')
+            error('Complementarity constraints indicators can only be replaced with binary variables');
+        end
+        F.clauses{i}.extra.indicators = replace(F.clauses{i}.extra.indicators,X,W,expand);
+    end
     if isempty(F.clauses{i}.data) | isa(F.clauses{i}.data,'double')
         keep(i)=0;
     else


### PR DESCRIPTION
Close #1504 