### PR TITLE
Minor changes to reduce memory usage

### DIFF
--- a/extras/solvesdp.m
+++ b/extras/solvesdp.m
@@ -417,10 +417,10 @@ end
 % TRY TO SOLVE PROBLEM
 % *************************************************************************
 if options.debug
-    eval(['output = ' solver.call '(interfacedata);']);
+    output = feval( solver.call, interfacedata );
 else
     try
-        eval(['output = ' solver.call '(interfacedata);']);
+        output = feval( solver.call, interfacedata );
     catch
         output = createOutputStructure(zeros(length(interfacedata.c),1)+NaN,[],[],9,yalmiperror(9,lasterr),[],[],nan);        
     end

--- a/extras/solvesdp.m
+++ b/extras/solvesdp.m
@@ -413,6 +413,8 @@ if strcmpi(solver.version,'geometric') || (strcmpi(solver.tag,'bnb') && strcmpi(
     end
 end
 
+clear varargin;
+
 % *************************************************************************
 % TRY TO SOLVE PROBLEM
 % *************************************************************************

--- a/solvers/callmosek.m
+++ b/solvers/callmosek.m
@@ -2,14 +2,14 @@ function output = callmosek(model)
 
 % Retrieve needed data
 options = model.options;
-F_struc = model.F_struc;
-c       = model.c;
-Q       = model.Q;
-K       = model.K;
-x0      = model.x0;
-integer_variables = model.integer_variables;
-binary_variables = model.binary_variables;
-extended_variables = model.extended_variables;
+% F_struc = model.F_struc;
+% c       = model.c;
+% Q       = model.Q;
+% K       = model.K;
+% x0      = model.x0;
+% integer_variables = model.integer_variables;
+% binary_variables = model.binary_variables;
+% extended_variables = model.extended_variables;
 ub      = model.ub;
 lb      = model.lb;
 mt      = model.monomtable;


### PR DESCRIPTION
These were prompted by working with an extremely large problem.

Using feval rather than eval should definitely help MATLAB optimise memory usage. And explicitly clearing varargin also helps as the possibility of debugging means MATLAB can't safely auto-clear variables even if they're never used again. The changes to callmosek.m probably make no difference.