### PR TITLE
Fix: extend recursivefieldnames to support MATLAB optimizer classes

### DIFF
--- a/extras/sdpsettings.m
+++ b/extras/sdpsettings.m
@@ -404,6 +404,9 @@ for i = 1:length(cNames)
     temporaryOptions = getfield(options,cNames{i});
     if isa(temporaryOptions,'struct')
         cNames = [cNames;recursivefieldnames(temporaryOptions,[cNames{i}])];
+    elseif isa(temporaryOptions,'optim.options.MultiAlgorithm')
+        temporaryOptions = cell2struct( cellfun(@(x) getfield(temporaryOptions,x), properties(temporaryOptions),'UniformOutput', false), properties(temporaryOptions), 1);
+        cNames = [cNames; recursivefieldnames(temporaryOptions,[cNames{i}])];
     end
 end
 for i = 1:length(cNames)


### PR DESCRIPTION
The validation in sdpsettings relied on recursivefieldnames, which only worked with structs. However, MATLAB internal optimizers return options as classes (e.g., optim.options.intlinprog, subclasses of optim.options.MultiAlgorithm). These were discarded, breaking cases like:

opts = sdpsettings('solver','intlinprog');
opts = sdpsettings(opts,'intlinprog.RelativeGapTolerance',relGap);

The fix converts the properties of optim.options.MultiAlgorithm objects into a struct before recursively extracting field names, preserving the expected code flow without exposing private fields.