### PR TITLE
Fix optimizer subsref warmstart bug

### DIFF
--- a/extras/@optimizer/subsref.m
+++ b/extras/@optimizer/subsref.m
@@ -261,6 +261,9 @@ elseif isequal(subs.type,'{}')
             self.model.parameterIndex = currentParametricIndex;
             self = optimizer_precalc(self);                 
             [self.model,keptvariablesIndex] = eliminatevariables(self.model,currentParametricIndex,thisData(:),allParametricIndex);
+            if ~isempty(self.lastsolution)
+                self.lastsolution = self.lastsolution(keptvariablesIndex);
+            end
             
             % Update as new optimizer in remaining variables, remap
             % parameters to currently used variables                                   


### PR DESCRIPTION
The following PR was generated by AI. It seems reasonable to me but it probably warrants additional scrutiny. AI text follows:

When partially instantiating an optimizer object, the lastsolution array was not being updated to remove the eliminated parameters, which resulted in a corrupted warm start for subsequent solver calls. This PR fixes the issue by slicing lastsolution using keptvariablesIndex.